### PR TITLE
Fix typo, path, missing semicolon.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,14 +73,14 @@ Make sure that your `$GOPATH/bin` is in your `$PATH`.
    +    option (gengo.grpc.gateway.ApiMethodOptions.api_options) = {
    +      path: "/v1/example/echo"
    +      method: "POST"
-   +    }
+   +    };
    +  }
     }
    ```
 3. Generate gRPC stub
    
    ```sh
-   protoc -I/usr/local/include -I. -I$GOPATH \
+   protoc -I/usr/local/include -I. -I$GOPATH/src \
      --go_out=plugins=grpc:. \
      path/to/your_service.proto
    ```
@@ -90,7 +90,7 @@ Make sure that your `$GOPATH/bin` is in your `$PATH`.
 4. Generate reverse-proxy
    
    ```sh
-   protoc -I/usr/local/include -I. -I$GOPATH \
+   protoc -I/usr/local/include -I. -I$GOPATH/src \
      --grpc-gateway_out=logtostderr=true:. \
      path/to/your_service.proto
    ```
@@ -155,7 +155,7 @@ More examples are available under `examples` directory.
 * Generating JSON API handlers
 * Method parameters in request body
 * Method parameters in request path
-* Mppping streaming APIs to JSON streams
+* Mapping streaming APIs to JSON streams
 
 ### Want to support
 But not yet.
@@ -163,7 +163,7 @@ But not yet.
 * bytes and enum fields in path parameter
 * Method parameters in query string
 * Encoding request/response body in application/x-www-form-urlencoded
-* Optinally generating the entrypoint
+* Optionally generating the entrypoint
 * Optionally emitting API definition for [Swagger](http://swagger.io)
 
 ### No plan to support


### PR DESCRIPTION
Hi there.

First off, thanks for making this! It seems very helpful and needed.

I'm still learning about grpc and protobufs, so I may be mistaken, but I think there were a few issues in the README that I had to figure out in order to get it to work. Please take a look.

I think they are valid fixes.

The first change:

```diff
@@ -73,14 +73,14 @@ Make sure that your `$GOPATH/bin` is in your `$PATH`.
    +    option (gengo.grpc.gateway.ApiMethodOptions.api_options) = {
    +      path: "/v1/example/echo"
    +      method: "POST"
-   +    }
+   +    };
    +  }
     }
    ```
```

I needed to add that semicolon, otherwise an error was being generated when running `protoc` command:

```
sample.proto:46:3: Expected ";".
```

Next change:

```diff
 3. Generate gRPC stub
    
    ```sh
-   protoc -I/usr/local/include -I. -I$GOPATH \
+   protoc -I/usr/local/include -I. -I$GOPATH/src \
      --go_out=plugins=grpc:. \
      path/to/your_service.proto
    ```
    
    It will generate a stub file `path/to/your_service.pb.go`.
    Now you can implement your service on top of the stub.
 4. Generate reverse-proxy
    
    ```sh
-   protoc -I/usr/local/include -I. -I$GOPATH \
+   protoc -I/usr/local/include -I. -I$GOPATH/src \
      --grpc-gateway_out=logtostderr=true:. \
      path/to/your_service.proto
    ```
```

I needed to make that change, otherwise `protoc` command generated this error:

```
sample.proto: Import "github.com/gengo/grpc-gateway/options/options.proto" was not found or had errors.
```

This change makes sense, as `options.proto` file is indeed located at `$GOPATH/src/github.com/gengo/grpc-gateway/options/options.proto` and not `$GOPATH/github.com/gengo/grpc-gateway/options/options.proto`.

The rest are just typo fixes.