### PR TITLE
Report semantic errors in the source to protoc

### DIFF
--- a/protoc-gen-grpc-gateway/descriptor/services.go
+++ b/protoc-gen-grpc-gateway/descriptor/services.go
@@ -15,17 +15,20 @@ import (
 // It must be called after loadFile is called for all files so that loadServices
 // can resolve names of message types and their fields.
 func (r *Registry) loadServices(targetFile string) error {
+	glog.V(1).Infof("Loading services from %s", targetFile)
 	file := r.files[targetFile]
 	if file == nil {
 		return fmt.Errorf("no such file: %s", targetFile)
 	}
 	var svcs []*Service
 	for _, sd := range file.GetService() {
+		glog.V(2).Infof("Registering %s", sd.GetName())
 		svc := &Service{
 			File: file,
 			ServiceDescriptorProto: sd,
 		}
 		for _, md := range sd.GetMethod() {
+			glog.V(2).Infof("Processing %s.%s", sd.GetName(), md.GetName())
 			opts, err := extractAPIOptions(md)
 			if err != nil {
 				glog.Errorf("Failed to extract ApiMethodOptions from %s.%s: %v", svc.GetName(), md.GetName(), err)
@@ -44,6 +47,7 @@ func (r *Registry) loadServices(targetFile string) error {
 		if len(svc.Methods) == 0 {
 			continue
 		}
+		glog.V(2).Infof("Registered %s with %d method(s)", svc.GetName(), len(svc.Methods))
 		svcs = append(svcs, svc)
 	}
 	file.Services = svcs

--- a/protoc-gen-grpc-gateway/gengateway/template.go
+++ b/protoc-gen-grpc-gateway/gengateway/template.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gengo/grpc-gateway/internal"
 	"github.com/gengo/grpc-gateway/protoc-gen-grpc-gateway/descriptor"
+	"github.com/golang/glog"
 )
 
 type param struct {
@@ -58,6 +59,7 @@ func applyTemplate(p param) (string, error) {
 	var methodSeen bool
 	for _, svc := range p.Services {
 		for _, meth := range svc.Methods {
+			glog.V(2).Infof("Processing %s.%s", svc.GetName(), meth.GetName())
 			methodSeen = true
 			for _, b := range meth.Bindings {
 				if err := handlerTemplate.Execute(w, binding{Binding: b}); err != nil {

--- a/protoc-gen-grpc-gateway/main.go
+++ b/protoc-gen-grpc-gateway/main.go
@@ -68,6 +68,7 @@ func main() {
 	reg.SetPrefix(*importPrefix)
 	if err := reg.Load(req); err != nil {
 		emitError(err)
+		return
 	}
 
 	g := gengateway.New(reg)
@@ -85,6 +86,7 @@ func main() {
 	glog.V(1).Info("Processed code generator request")
 	if err != nil {
 		emitError(err)
+		return
 	}
 	emitFiles(out)
 }


### PR DESCRIPTION
Parse errors happening in `Registry.Load` used to be ignored.  This PR lets protoc-gen-grpc-gateway report such errors to protoc.