### PR TITLE
Update examples with HTTP header context annotation

### DIFF
--- a/examples/a_bit_of_everything.pb.gw.go
+++ b/examples/a_bit_of_everything.pb.gw.go
@@ -378,7 +378,7 @@ func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.Se
 	client := NewABitOfEverythingServiceClient(conn)
 
 	mux.Handle("POST", pattern_ABitOfEverythingService_Create_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
-		resp, err := request_ABitOfEverythingService_Create_0(ctx, client, req, pathParams)
+		resp, err := request_ABitOfEverythingService_Create_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
 		if err != nil {
 			runtime.HTTPError(w, err)
 			return
@@ -389,7 +389,7 @@ func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.Se
 	})
 
 	mux.Handle("POST", pattern_ABitOfEverythingService_CreateBody_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
-		resp, err := request_ABitOfEverythingService_CreateBody_0(ctx, client, req, pathParams)
+		resp, err := request_ABitOfEverythingService_CreateBody_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
 		if err != nil {
 			runtime.HTTPError(w, err)
 			return
@@ -400,7 +400,7 @@ func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.Se
 	})
 
 	mux.Handle("POST", pattern_ABitOfEverythingService_BulkCreate_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
-		resp, err := request_ABitOfEverythingService_BulkCreate_0(ctx, client, req, pathParams)
+		resp, err := request_ABitOfEverythingService_BulkCreate_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
 		if err != nil {
 			runtime.HTTPError(w, err)
 			return
@@ -411,7 +411,7 @@ func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.Se
 	})
 
 	mux.Handle("GET", pattern_ABitOfEverythingService_Lookup_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
-		resp, err := request_ABitOfEverythingService_Lookup_0(ctx, client, req, pathParams)
+		resp, err := request_ABitOfEverythingService_Lookup_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
 		if err != nil {
 			runtime.HTTPError(w, err)
 			return
@@ -422,7 +422,7 @@ func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.Se
 	})
 
 	mux.Handle("GET", pattern_ABitOfEverythingService_List_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
-		resp, err := request_ABitOfEverythingService_List_0(ctx, client, req, pathParams)
+		resp, err := request_ABitOfEverythingService_List_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
 		if err != nil {
 			runtime.HTTPError(w, err)
 			return
@@ -433,7 +433,7 @@ func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.Se
 	})
 
 	mux.Handle("PUT", pattern_ABitOfEverythingService_Update_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
-		resp, err := request_ABitOfEverythingService_Update_0(ctx, client, req, pathParams)
+		resp, err := request_ABitOfEverythingService_Update_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
 		if err != nil {
 			runtime.HTTPError(w, err)
 			return
@@ -444,7 +444,7 @@ func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.Se
 	})
 
 	mux.Handle("DELETE", pattern_ABitOfEverythingService_Delete_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
-		resp, err := request_ABitOfEverythingService_Delete_0(ctx, client, req, pathParams)
+		resp, err := request_ABitOfEverythingService_Delete_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
 		if err != nil {
 			runtime.HTTPError(w, err)
 			return
@@ -455,7 +455,7 @@ func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.Se
 	})
 
 	mux.Handle("GET", pattern_ABitOfEverythingService_Echo_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
-		resp, err := request_ABitOfEverythingService_Echo_0(ctx, client, req, pathParams)
+		resp, err := request_ABitOfEverythingService_Echo_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
 		if err != nil {
 			runtime.HTTPError(w, err)
 			return
@@ -466,7 +466,7 @@ func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.Se
 	})
 
 	mux.Handle("POST", pattern_ABitOfEverythingService_Echo_1, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
-		resp, err := request_ABitOfEverythingService_Echo_1(ctx, client, req, pathParams)
+		resp, err := request_ABitOfEverythingService_Echo_1(runtime.AnnotateContext(ctx, req), client, req, pathParams)
 		if err != nil {
 			runtime.HTTPError(w, err)
 			return
@@ -477,7 +477,7 @@ func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.Se
 	})
 
 	mux.Handle("GET", pattern_ABitOfEverythingService_Echo_2, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
-		resp, err := request_ABitOfEverythingService_Echo_2(ctx, client, req, pathParams)
+		resp, err := request_ABitOfEverythingService_Echo_2(runtime.AnnotateContext(ctx, req), client, req, pathParams)
 		if err != nil {
 			runtime.HTTPError(w, err)
 			return
@@ -488,7 +488,7 @@ func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.Se
 	})
 
 	mux.Handle("POST", pattern_ABitOfEverythingService_BulkEcho_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
-		resp, err := request_ABitOfEverythingService_BulkEcho_0(ctx, client, req, pathParams)
+		resp, err := request_ABitOfEverythingService_BulkEcho_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
 		if err != nil {
 			runtime.HTTPError(w, err)
 			return

--- a/examples/echo_service.pb.gw.go
+++ b/examples/echo_service.pb.gw.go
@@ -88,7 +88,7 @@ func RegisterEchoServiceHandler(ctx context.Context, mux *runtime.ServeMux, conn
 	client := NewEchoServiceClient(conn)
 
 	mux.Handle("POST", pattern_EchoService_Echo_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
-		resp, err := request_EchoService_Echo_0(ctx, client, req, pathParams)
+		resp, err := request_EchoService_Echo_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
 		if err != nil {
 			runtime.HTTPError(w, err)
 			return
@@ -99,7 +99,7 @@ func RegisterEchoServiceHandler(ctx context.Context, mux *runtime.ServeMux, conn
 	})
 
 	mux.Handle("POST", pattern_EchoService_EchoBody_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
-		resp, err := request_EchoService_EchoBody_0(ctx, client, req, pathParams)
+		resp, err := request_EchoService_EchoBody_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
 		if err != nil {
 			runtime.HTTPError(w, err)
 			return


### PR DESCRIPTION
Generated codes in examples/ are regenerated with
e5d20af097e6e145eaaee85961dd61b01c0d66cd (#18).