### PR TITLE
[Experimental] Make the response forwarder function customizable

### DIFF
--- a/examples/a_bit_of_everything.pb.gw.go
+++ b/examples/a_bit_of_everything.pb.gw.go
@@ -384,7 +384,7 @@ func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.Se
 			return
 		}
 
-		runtime.ForwardResponseMessage(ctx, w, resp)
+		forward_ABitOfEverythingService_Create_0(ctx, w, req, resp)
 
 	})
 
@@ -395,7 +395,7 @@ func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.Se
 			return
 		}
 
-		runtime.ForwardResponseMessage(ctx, w, resp)
+		forward_ABitOfEverythingService_CreateBody_0(ctx, w, req, resp)
 
 	})
 
@@ -406,7 +406,7 @@ func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.Se
 			return
 		}
 
-		runtime.ForwardResponseMessage(ctx, w, resp)
+		forward_ABitOfEverythingService_BulkCreate_0(ctx, w, req, resp)
 
 	})
 
@@ -417,7 +417,7 @@ func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.Se
 			return
 		}
 
-		runtime.ForwardResponseMessage(ctx, w, resp)
+		forward_ABitOfEverythingService_Lookup_0(ctx, w, req, resp)
 
 	})
 
@@ -428,7 +428,7 @@ func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.Se
 			return
 		}
 
-		runtime.ForwardResponseStream(w, func() (proto.Message, error) { return resp.Recv() })
+		forward_ABitOfEverythingService_List_0(ctx, w, req, func() (proto.Message, error) { return resp.Recv() })
 
 	})
 
@@ -439,7 +439,7 @@ func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.Se
 			return
 		}
 
-		runtime.ForwardResponseMessage(ctx, w, resp)
+		forward_ABitOfEverythingService_Update_0(ctx, w, req, resp)
 
 	})
 
@@ -450,7 +450,7 @@ func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.Se
 			return
 		}
 
-		runtime.ForwardResponseMessage(ctx, w, resp)
+		forward_ABitOfEverythingService_Delete_0(ctx, w, req, resp)
 
 	})
 
@@ -461,7 +461,7 @@ func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.Se
 			return
 		}
 
-		runtime.ForwardResponseMessage(ctx, w, resp)
+		forward_ABitOfEverythingService_Echo_0(ctx, w, req, resp)
 
 	})
 
@@ -472,7 +472,7 @@ func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.Se
 			return
 		}
 
-		runtime.ForwardResponseMessage(ctx, w, resp)
+		forward_ABitOfEverythingService_Echo_1(ctx, w, req, resp)
 
 	})
 
@@ -483,7 +483,7 @@ func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.Se
 			return
 		}
 
-		runtime.ForwardResponseMessage(ctx, w, resp)
+		forward_ABitOfEverythingService_Echo_2(ctx, w, req, resp)
 
 	})
 
@@ -494,7 +494,7 @@ func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.Se
 			return
 		}
 
-		runtime.ForwardResponseStream(w, func() (proto.Message, error) { return resp.Recv() })
+		forward_ABitOfEverythingService_BulkEcho_0(ctx, w, req, func() (proto.Message, error) { return resp.Recv() })
 
 	})
 
@@ -523,4 +523,28 @@ var (
 	pattern_ABitOfEverythingService_Echo_2 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v2", "example", "echo"}, ""))
 
 	pattern_ABitOfEverythingService_BulkEcho_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"v1", "example", "a_bit_of_everything", "echo"}, ""))
+)
+
+var (
+	forward_ABitOfEverythingService_Create_0 = runtime.ForwardResponseMessage
+
+	forward_ABitOfEverythingService_CreateBody_0 = runtime.ForwardResponseMessage
+
+	forward_ABitOfEverythingService_BulkCreate_0 = runtime.ForwardResponseMessage
+
+	forward_ABitOfEverythingService_Lookup_0 = runtime.ForwardResponseMessage
+
+	forward_ABitOfEverythingService_List_0 = runtime.ForwardResponseStream
+
+	forward_ABitOfEverythingService_Update_0 = runtime.ForwardResponseMessage
+
+	forward_ABitOfEverythingService_Delete_0 = runtime.ForwardResponseMessage
+
+	forward_ABitOfEverythingService_Echo_0 = runtime.ForwardResponseMessage
+
+	forward_ABitOfEverythingService_Echo_1 = runtime.ForwardResponseMessage
+
+	forward_ABitOfEverythingService_Echo_2 = runtime.ForwardResponseMessage
+
+	forward_ABitOfEverythingService_BulkEcho_0 = runtime.ForwardResponseStream
 )

--- a/examples/echo_service.pb.gw.go
+++ b/examples/echo_service.pb.gw.go
@@ -94,7 +94,7 @@ func RegisterEchoServiceHandler(ctx context.Context, mux *runtime.ServeMux, conn
 			return
 		}
 
-		runtime.ForwardResponseMessage(ctx, w, resp)
+		forward_EchoService_Echo_0(ctx, w, req, resp)
 
 	})
 
@@ -105,7 +105,7 @@ func RegisterEchoServiceHandler(ctx context.Context, mux *runtime.ServeMux, conn
 			return
 		}
 
-		runtime.ForwardResponseMessage(ctx, w, resp)
+		forward_EchoService_EchoBody_0(ctx, w, req, resp)
 
 	})
 
@@ -116,4 +116,10 @@ var (
 	pattern_EchoService_Echo_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"v1", "example", "echo", "id"}, ""))
 
 	pattern_EchoService_EchoBody_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "example", "echo_body"}, ""))
+)
+
+var (
+	forward_EchoService_Echo_0 = runtime.ForwardResponseMessage
+
+	forward_EchoService_EchoBody_0 = runtime.ForwardResponseMessage
 )

--- a/protoc-gen-grpc-gateway/gengateway/template.go
+++ b/protoc-gen-grpc-gateway/gengateway/template.go
@@ -228,9 +228,9 @@ func Register{{$svc.GetName}}Handler(ctx context.Context, mux *runtime.ServeMux,
 			return
 		}
 		{{if $m.GetServerStreaming}}
-		runtime.ForwardResponseStream(w, func() (proto.Message, error) { return resp.Recv() })
+		forward_{{$svc.GetName}}_{{$m.GetName}}_{{$b.Index}}(ctx, w, req, func() (proto.Message, error) { return resp.Recv() })
 		{{else}}
-		runtime.ForwardResponseMessage(ctx, w, resp)
+		forward_{{$svc.GetName}}_{{$m.GetName}}_{{$b.Index}}(ctx, w, req, resp)
 		{{end}}
 	})
 	{{end}}
@@ -242,6 +242,14 @@ var (
 	{{range $m := $svc.Methods}}
 	{{range $b := $m.Bindings}}
 	pattern_{{$svc.GetName}}_{{$m.GetName}}_{{$b.Index}} = runtime.MustPattern(runtime.NewPattern({{$b.PathTmpl.Version}}, {{$b.PathTmpl.OpCodes | printf "%#v"}}, {{$b.PathTmpl.Pool | printf "%#v"}}, {{$b.PathTmpl.Verb | printf "%q"}}))
+	{{end}}
+	{{end}}
+)
+
+var (
+	{{range $m := $svc.Methods}}
+	{{range $b := $m.Bindings}}
+	forward_{{$svc.GetName}}_{{$m.GetName}}_{{$b.Index}} = {{if $m.GetServerStreaming}}runtime.ForwardResponseStream{{else}}runtime.ForwardResponseMessage{{end}}
 	{{end}}
 	{{end}}
 )

--- a/runtime/handler.go
+++ b/runtime/handler.go
@@ -17,7 +17,7 @@ type responseStreamChunk struct {
 }
 
 // ForwardResponseStream forwards the stream from gRPC server to REST client.
-func ForwardResponseStream(w http.ResponseWriter, recv func() (proto.Message, error)) {
+func ForwardResponseStream(ctx context.Context, w http.ResponseWriter, req *http.Request, recv func() (proto.Message, error)) {
 	f, ok := w.(http.Flusher)
 	if !ok {
 		glog.Errorf("Flush not supported in %T", w)
@@ -58,8 +58,8 @@ func ForwardResponseStream(w http.ResponseWriter, recv func() (proto.Message, er
 	}
 }
 
-// ForwardResponseMessage forwards the message from gRPC server to REST client.
-func ForwardResponseMessage(ctx context.Context, w http.ResponseWriter, resp proto.Message) {
+// ForwardResponseMessage forwards the message "resp" from gRPC server to REST client.
+func ForwardResponseMessage(ctx context.Context, w http.ResponseWriter, req *http.Request, resp proto.Message) {
 	buf, err := json.Marshal(resp)
 	if err != nil {
 		glog.Errorf("Marshal error: %v", err)


### PR DESCRIPTION
Sometimes RESTful API needs something does not fit to just call-return semantics -- e.g. redirection based on the result.
It looks to be natural to support such a thing in an the gateway rather than to emit extra information from gRPC backend.

Users can do that by customizing the forwarder function.