### PR TITLE
Reflection fix of proto3 nested messages.

### DIFF
--- a/protoc-gen-grpc-gateway/descriptor/types.go
+++ b/protoc-gen-grpc-gateway/descriptor/types.go
@@ -196,6 +196,14 @@ func (p FieldPath) String() string {
 	return strings.Join(components, ".")
 }
 
+// IsNestedProto3 indicates whether the FieldPath is a nested Proto3 path.
+func (p FieldPath) IsNestedProto3() bool {
+	if len(p) > 1 && !p[0].Target.Message.File.proto2() {
+		return true
+	}
+	return false
+}
+
 // RHS is a right-hand-side expression in go to be used to assign a value to the target field.
 // It starts with "msgExpr", which is the go expression of the method request object.
 func (p FieldPath) RHS(msgExpr string) string {

--- a/protoc-gen-grpc-gateway/gengateway/template.go
+++ b/protoc-gen-grpc-gateway/gengateway/template.go
@@ -188,7 +188,11 @@ var (
 	if !ok {
 		return nil, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", {{$param | printf "%q"}})
 	}
+{{if $param.IsNestedProto3 }}
+	err = runtime.PopulateFieldFromPath(&protoReq, {{$param | printf "%q"}}, val)
+{{else}}
 	{{$param.RHS "protoReq"}}, err = {{$param.ConvertFuncExpr}}(val)
+{{end}}
 	if err != nil {
 		return nil, err
 	}

--- a/runtime/query.go
+++ b/runtime/query.go
@@ -19,14 +19,21 @@ func PopulateQueryParameters(msg proto.Message, values url.Values, filter *inter
 		if filter.HasCommonPrefix(fieldPath) {
 			continue
 		}
-		if err := populateQueryParameter(msg, fieldPath, values); err != nil {
+		if err := populateFieldValueFromPath(msg, fieldPath, values); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func populateQueryParameter(msg proto.Message, fieldPath []string, values []string) error {
+// PopulateFieldFromPath sets a value in a nested Protobuf structure.
+// It instantiates missing protobuf fields as it goes.
+func PopulateFieldFromPath(msg proto.Message, fieldPathString string, value string) error {
+	fieldPath := strings.Split(fieldPathString, ".")
+	return populateFieldValueFromPath(msg, fieldPath, []string{value})
+}
+
+func populateFieldValueFromPath(msg proto.Message, fieldPath []string, values []string) error {
 	m := reflect.ValueOf(msg)
 	if m.Kind() != reflect.Ptr {
 		return fmt.Errorf("unexpected type %T: %v", msg, msg)


### PR DESCRIPTION
This doesn't require any changes to golang/protobuf.
And reuses the code already written for query string filtering.