### PR TITLE
Fixes #4

### DIFF
--- a/runtime/context.go
+++ b/runtime/context.go
@@ -22,6 +22,9 @@ func AnnotateContext(ctx context.Context, req *http.Request) context.Context {
 		if strings.HasPrefix(key, metadataHeaderPrefix) {
 			pairs = append(pairs, key[len(metadataHeaderPrefix):], val[0])
 		}
+		if key == "Authorization" {
+			pairs = append(pairs, key, val[0])
+		}
 	}
 
 	if len(pairs) != 0 {


### PR DESCRIPTION
Both OAuth2 and HTTP Basic auth use this header, so it makes sense to pass it though and allow the GRPC endpoint to handle it however it wishes.