### PR TITLE
Follow a change of go package name convention in protoc-gen-go

### DIFF
--- a/protoc-gen-grpc-gateway/descriptor/services.go
+++ b/protoc-gen-grpc-gateway/descriptor/services.go
@@ -14,12 +14,8 @@ import (
 // loadServices registers services and their methods from "targetFile" to "r".
 // It must be called after loadFile is called for all files so that loadServices
 // can resolve names of message types and their fields.
-func (r *Registry) loadServices(targetFile string) error {
-	glog.V(1).Infof("Loading services from %s", targetFile)
-	file := r.files[targetFile]
-	if file == nil {
-		return fmt.Errorf("no such file: %s", targetFile)
-	}
+func (r *Registry) loadServices(file *File) error {
+	glog.V(1).Infof("Loading services from %s", file.GetName())
 	var svcs []*Service
 	for _, sd := range file.GetService() {
 		glog.V(2).Infof("Registering %s", sd.GetName())

--- a/protoc-gen-grpc-gateway/descriptor/services_test.go
+++ b/protoc-gen-grpc-gateway/descriptor/services_test.go
@@ -22,7 +22,7 @@ func testExtractServices(t *testing.T, input []*descriptor.FileDescriptorProto, 
 	for _, file := range input {
 		reg.loadFile(file)
 	}
-	err := reg.loadServices(target)
+	err := reg.loadServices(reg.files[target])
 	if err != nil {
 		t.Errorf("loadServices(%q) failed with %v; want success; files=%v", target, err, input)
 	}
@@ -914,7 +914,7 @@ func TestExtractServicesWithError(t *testing.T) {
 			reg.loadFile(&fd)
 			fds = append(fds, &fd)
 		}
-		err := reg.loadServices(spec.target)
+		err := reg.loadServices(reg.files[spec.target])
 		if err == nil {
 			t.Errorf("loadServices(%q) succeeded; want an error; files=%v", spec.target, spec.srcs)
 		}

--- a/protoc-gen-grpc-gateway/main.go
+++ b/protoc-gen-grpc-gateway/main.go
@@ -65,13 +65,13 @@ func main() {
 		}
 	}
 
+	g := gengateway.New(reg)
+
 	reg.SetPrefix(*importPrefix)
 	if err := reg.Load(req); err != nil {
 		emitError(err)
 		return
 	}
-
-	g := gengateway.New(reg)
 
 	var targets []*descriptor.File
 	for _, target := range req.FileToGenerate {


### PR DESCRIPTION
Follows the change golang/protobuf@dded9133a99a3cd7c3a9d24a9f85c2b8ef76ff31.

This fixes #22 as a side-effect.