### PR TITLE
Add log package

### DIFF
--- a/examples/examplepb/a_bit_of_everything.pb.gw.go
+++ b/examples/examplepb/a_bit_of_everything.pb.gw.go
@@ -15,9 +15,9 @@ import (
 	"net/http"
 
 	"github.com/gengo/grpc-gateway/examples/sub"
+	"github.com/gengo/grpc-gateway/log"
 	"github.com/gengo/grpc-gateway/runtime"
 	"github.com/gengo/grpc-gateway/utilities"
-	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
@@ -218,7 +218,7 @@ func request_ABitOfEverythingService_CreateBody_0(ctx context.Context, client AB
 func request_ABitOfEverythingService_BulkCreate_0(ctx context.Context, client ABitOfEverythingServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, error) {
 	stream, err := client.BulkCreate(ctx)
 	if err != nil {
-		glog.Errorf("Failed to start streaming: %v", err)
+		log.Errorf("Failed to start streaming: %v", err)
 		return nil, err
 	}
 	dec := json.NewDecoder(req.Body)
@@ -229,11 +229,11 @@ func request_ABitOfEverythingService_BulkCreate_0(ctx context.Context, client AB
 			break
 		}
 		if err != nil {
-			glog.Errorf("Failed to decode request: %v", err)
+			log.Errorf("Failed to decode request: %v", err)
 			return nil, grpc.Errorf(codes.InvalidArgument, "%v", err)
 		}
 		if err = stream.Send(&protoReq); err != nil {
-			glog.Errorf("Failed to send request: %v", err)
+			log.Errorf("Failed to send request: %v", err)
 			return nil, err
 		}
 	}
@@ -375,7 +375,7 @@ func request_ABitOfEverythingService_Echo_2(ctx context.Context, client ABitOfEv
 func request_ABitOfEverythingService_BulkEcho_0(ctx context.Context, client ABitOfEverythingServiceClient, req *http.Request, pathParams map[string]string) (ABitOfEverythingService_BulkEchoClient, error) {
 	stream, err := client.BulkEcho(ctx)
 	if err != nil {
-		glog.Errorf("Failed to start streaming: %v", err)
+		log.Errorf("Failed to start streaming: %v", err)
 		return nil, err
 	}
 	dec := json.NewDecoder(req.Body)
@@ -386,17 +386,17 @@ func request_ABitOfEverythingService_BulkEcho_0(ctx context.Context, client ABit
 			break
 		}
 		if err != nil {
-			glog.Errorf("Failed to decode request: %v", err)
+			log.Errorf("Failed to decode request: %v", err)
 			return nil, grpc.Errorf(codes.InvalidArgument, "%v", err)
 		}
 		if err = stream.Send(&protoReq); err != nil {
-			glog.Errorf("Failed to send request: %v", err)
+			log.Errorf("Failed to send request: %v", err)
 			return nil, err
 		}
 	}
 
 	if err = stream.CloseSend(); err != nil {
-		glog.Errorf("Failed to terminate client stream: %v", err)
+		log.Errorf("Failed to terminate client stream: %v", err)
 		return nil, err
 	}
 	return stream, nil
@@ -406,21 +406,21 @@ func request_ABitOfEverythingService_BulkEcho_0(ctx context.Context, client ABit
 // RegisterABitOfEverythingServiceHandlerFromEndpoint is same as RegisterABitOfEverythingServiceHandler but
 // automatically dials to "endpoint" and closes the connection when "ctx" gets done.
 func RegisterABitOfEverythingServiceHandlerFromEndpoint(ctx context.Context, mux *runtime.ServeMux, endpoint string) (err error) {
-	conn, err := grpc.Dial(endpoint)
+	conn, err := grpc.Dial(endpoint, grpc.WithInsecure())
 	if err != nil {
 		return err
 	}
 	defer func() {
 		if err != nil {
 			if cerr := conn.Close(); cerr != nil {
-				glog.Errorf("Failed to close conn to %s: %v", endpoint, cerr)
+				log.Errorf("Failed to close conn to %s: %v", endpoint, cerr)
 			}
 			return
 		}
 		go func() {
 			<-ctx.Done()
 			if cerr := conn.Close(); cerr != nil {
-				glog.Errorf("Failed to close conn to %s: %v", endpoint, cerr)
+				log.Errorf("Failed to close conn to %s: %v", endpoint, cerr)
 			}
 		}()
 	}()

--- a/examples/examplepb/echo_service.pb.gw.go
+++ b/examples/examplepb/echo_service.pb.gw.go
@@ -14,9 +14,9 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/gengo/grpc-gateway/log"
 	"github.com/gengo/grpc-gateway/runtime"
 	"github.com/gengo/grpc-gateway/utilities"
-	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
@@ -66,21 +66,21 @@ func request_EchoService_EchoBody_0(ctx context.Context, client EchoServiceClien
 // RegisterEchoServiceHandlerFromEndpoint is same as RegisterEchoServiceHandler but
 // automatically dials to "endpoint" and closes the connection when "ctx" gets done.
 func RegisterEchoServiceHandlerFromEndpoint(ctx context.Context, mux *runtime.ServeMux, endpoint string) (err error) {
-	conn, err := grpc.Dial(endpoint)
+	conn, err := grpc.Dial(endpoint, grpc.WithInsecure())
 	if err != nil {
 		return err
 	}
 	defer func() {
 		if err != nil {
 			if cerr := conn.Close(); cerr != nil {
-				glog.Errorf("Failed to close conn to %s: %v", endpoint, cerr)
+				log.Errorf("Failed to close conn to %s: %v", endpoint, cerr)
 			}
 			return
 		}
 		go func() {
 			<-ctx.Done()
 			if cerr := conn.Close(); cerr != nil {
-				glog.Errorf("Failed to close conn to %s: %v", endpoint, cerr)
+				log.Errorf("Failed to close conn to %s: %v", endpoint, cerr)
 			}
 		}()
 	}()

--- a/examples/examplepb/flow_combination.pb.gw.go
+++ b/examples/examplepb/flow_combination.pb.gw.go
@@ -14,9 +14,9 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/gengo/grpc-gateway/log"
 	"github.com/gengo/grpc-gateway/runtime"
 	"github.com/gengo/grpc-gateway/utilities"
-	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
@@ -44,7 +44,7 @@ func request_FlowCombination_RpcEmptyStream_0(ctx context.Context, client FlowCo
 func request_FlowCombination_StreamEmptyRpc_0(ctx context.Context, client FlowCombinationClient, req *http.Request, pathParams map[string]string) (proto.Message, error) {
 	stream, err := client.StreamEmptyRpc(ctx)
 	if err != nil {
-		glog.Errorf("Failed to start streaming: %v", err)
+		log.Errorf("Failed to start streaming: %v", err)
 		return nil, err
 	}
 	dec := json.NewDecoder(req.Body)
@@ -55,11 +55,11 @@ func request_FlowCombination_StreamEmptyRpc_0(ctx context.Context, client FlowCo
 			break
 		}
 		if err != nil {
-			glog.Errorf("Failed to decode request: %v", err)
+			log.Errorf("Failed to decode request: %v", err)
 			return nil, grpc.Errorf(codes.InvalidArgument, "%v", err)
 		}
 		if err = stream.Send(&protoReq); err != nil {
-			glog.Errorf("Failed to send request: %v", err)
+			log.Errorf("Failed to send request: %v", err)
 			return nil, err
 		}
 	}
@@ -71,7 +71,7 @@ func request_FlowCombination_StreamEmptyRpc_0(ctx context.Context, client FlowCo
 func request_FlowCombination_StreamEmptyStream_0(ctx context.Context, client FlowCombinationClient, req *http.Request, pathParams map[string]string) (FlowCombination_StreamEmptyStreamClient, error) {
 	stream, err := client.StreamEmptyStream(ctx)
 	if err != nil {
-		glog.Errorf("Failed to start streaming: %v", err)
+		log.Errorf("Failed to start streaming: %v", err)
 		return nil, err
 	}
 	dec := json.NewDecoder(req.Body)
@@ -82,17 +82,17 @@ func request_FlowCombination_StreamEmptyStream_0(ctx context.Context, client Flo
 			break
 		}
 		if err != nil {
-			glog.Errorf("Failed to decode request: %v", err)
+			log.Errorf("Failed to decode request: %v", err)
 			return nil, grpc.Errorf(codes.InvalidArgument, "%v", err)
 		}
 		if err = stream.Send(&protoReq); err != nil {
-			glog.Errorf("Failed to send request: %v", err)
+			log.Errorf("Failed to send request: %v", err)
 			return nil, err
 		}
 	}
 
 	if err = stream.CloseSend(); err != nil {
-		glog.Errorf("Failed to terminate client stream: %v", err)
+		log.Errorf("Failed to terminate client stream: %v", err)
 		return nil, err
 	}
 	return stream, nil
@@ -786,21 +786,21 @@ func request_FlowCombination_RpcPathNestedStream_2(ctx context.Context, client F
 // RegisterFlowCombinationHandlerFromEndpoint is same as RegisterFlowCombinationHandler but
 // automatically dials to "endpoint" and closes the connection when "ctx" gets done.
 func RegisterFlowCombinationHandlerFromEndpoint(ctx context.Context, mux *runtime.ServeMux, endpoint string) (err error) {
-	conn, err := grpc.Dial(endpoint)
+	conn, err := grpc.Dial(endpoint, grpc.WithInsecure())
 	if err != nil {
 		return err
 	}
 	defer func() {
 		if err != nil {
 			if cerr := conn.Close(); cerr != nil {
-				glog.Errorf("Failed to close conn to %s: %v", endpoint, cerr)
+				log.Errorf("Failed to close conn to %s: %v", endpoint, cerr)
 			}
 			return
 		}
 		go func() {
 			<-ctx.Done()
 			if cerr := conn.Close(); cerr != nil {
-				glog.Errorf("Failed to close conn to %s: %v", endpoint, cerr)
+				log.Errorf("Failed to close conn to %s: %v", endpoint, cerr)
 			}
 		}()
 	}()

--- a/log/glog/glog.go
+++ b/log/glog/glog.go
@@ -1,0 +1,39 @@
+/*
+Package glog wraps github.com/golang/glog for grpc-gateway logging.
+*/
+package glog
+
+import (
+	"github.com/gengo/grpc-gateway/log"
+	"github.com/golang/glog"
+)
+
+func init() {
+	log.SetLogger(&gLogger{})
+}
+
+type gLogger struct{}
+
+func (l *gLogger) Infof(format string, args ...interface{}) {
+	glog.Infof(format, args...)
+}
+
+func (l *gLogger) Infoln(args ...interface{}) {
+	glog.Infoln(args...)
+}
+
+func (l *gLogger) Warnf(format string, args ...interface{}) {
+	glog.Warningf(format, args...)
+}
+
+func (l *gLogger) Warnln(args ...interface{}) {
+	glog.Warningln(args...)
+}
+
+func (l *gLogger) Errorf(format string, args ...interface{}) {
+	glog.Errorf(format, args...)
+}
+
+func (l *gLogger) Errorln(args ...interface{}) {
+	glog.Errorln(args...)
+}

--- a/log/log.go
+++ b/log/log.go
@@ -1,0 +1,61 @@
+/*
+Package log defines logging for grpc-gateway.
+*/
+package log
+
+import (
+	"log"
+	"os"
+)
+
+var globalLogger Logger = NewLogger(log.New(os.Stderr, "", log.LstdFlags))
+
+// Logger provides an interface for logging implementations for grpc-gateway.
+type Logger interface {
+	Infof(format string, args ...interface{})
+	Infoln(args ...interface{})
+	Warnf(format string, args ...interface{})
+	Warnln(args ...interface{})
+	Errorf(format string, args ...interface{})
+	Errorln(args ...interface{})
+}
+
+// SetLogger sets the logger that is used in grpc-gateway.
+func SetLogger(l Logger) {
+	globalLogger = l
+}
+
+// NewLogger returns a Logger that wraps a log.Logger from Go's standard log package.
+func NewLogger(l *log.Logger) Logger {
+	return newLogger(l)
+}
+
+// Infof logs an info message in the manner of fmt.Printf.
+func Infof(format string, args ...interface{}) {
+	globalLogger.Infof(format, args...)
+}
+
+// Infoln logs an info message in the manner of fmt.Println.
+func Infoln(args ...interface{}) {
+	globalLogger.Infoln(args...)
+}
+
+// Warnf logs an info message in the manner of fmt.Printf.
+func Warnf(format string, args ...interface{}) {
+	globalLogger.Warnf(format, args...)
+}
+
+// Warnln logs an info message in the manner of fmt.Println.
+func Warnln(args ...interface{}) {
+	globalLogger.Warnln(args...)
+}
+
+// Errorf logs an info message in the manner of fmt.Printf.
+func Errorf(format string, args ...interface{}) {
+	globalLogger.Errorf(format, args...)
+}
+
+// Errorln logs an info message in the manner of fmt.Println.
+func Errorln(args ...interface{}) {
+	globalLogger.Errorln(args...)
+}

--- a/log/logger.go
+++ b/log/logger.go
@@ -1,0 +1,35 @@
+package log
+
+import "log"
+
+type logger struct {
+	*log.Logger
+}
+
+func newLogger(l *log.Logger) *logger {
+	return &logger{l}
+}
+
+func (l *logger) Infof(format string, args ...interface{}) {
+	l.Printf(format, args...)
+}
+
+func (l *logger) Infoln(args ...interface{}) {
+	l.Println(args...)
+}
+
+func (l *logger) Warnf(format string, args ...interface{}) {
+	l.Printf(format, args...)
+}
+
+func (l *logger) Warnln(args ...interface{}) {
+	l.Println(args...)
+}
+
+func (l *logger) Errorf(format string, args ...interface{}) {
+	l.Printf(format, args...)
+}
+
+func (l *logger) Errorln(args ...interface{}) {
+	l.Println(args...)
+}

--- a/protoc-gen-grpc-gateway/descriptor/registry.go
+++ b/protoc-gen-grpc-gateway/descriptor/registry.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/golang/glog"
+	"github.com/gengo/grpc-gateway/log"
 	descriptor "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	plugin "github.com/golang/protobuf/protoc-gen-go/plugin"
 )
@@ -108,7 +108,7 @@ func (r *Registry) registerMsg(file *File, outerPath []string, msgs []*descripto
 		}
 		file.Messages = append(file.Messages, m)
 		r.msgs[m.FQMN()] = m
-		glog.V(1).Infof("register name: %s", m.FQMN())
+		log.Infof("register name: %s", m.FQMN())
 
 		var outers []string
 		outers = append(outers, outerPath...)
@@ -120,7 +120,7 @@ func (r *Registry) registerMsg(file *File, outerPath []string, msgs []*descripto
 // LookupMsg looks up a message type by "name".
 // It tries to resolve "name" from "location" if "name" is a relative message name.
 func (r *Registry) LookupMsg(location, name string) (*Message, error) {
-	glog.V(1).Infof("lookup %s from %s", name, location)
+	log.Infof("lookup %s from %s", name, location)
 	if strings.HasPrefix(name, ".") {
 		m, ok := r.msgs[name]
 		if !ok {

--- a/protoc-gen-grpc-gateway/descriptor/services.go
+++ b/protoc-gen-grpc-gateway/descriptor/services.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/gengo/grpc-gateway/log"
 	"github.com/gengo/grpc-gateway/protoc-gen-grpc-gateway/httprule"
 	options "github.com/gengo/grpc-gateway/third_party/googleapis/google/api"
-	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
 	descriptor "github.com/golang/protobuf/protoc-gen-go/descriptor"
 )
@@ -15,23 +15,23 @@ import (
 // It must be called after loadFile is called for all files so that loadServices
 // can resolve names of message types and their fields.
 func (r *Registry) loadServices(file *File) error {
-	glog.V(1).Infof("Loading services from %s", file.GetName())
+	log.Infof("Loading services from %s", file.GetName())
 	var svcs []*Service
 	for _, sd := range file.GetService() {
-		glog.V(2).Infof("Registering %s", sd.GetName())
+		log.Infof("Registering %s", sd.GetName())
 		svc := &Service{
 			File: file,
 			ServiceDescriptorProto: sd,
 		}
 		for _, md := range sd.GetMethod() {
-			glog.V(2).Infof("Processing %s.%s", sd.GetName(), md.GetName())
+			log.Infof("Processing %s.%s", sd.GetName(), md.GetName())
 			opts, err := extractAPIOptions(md)
 			if err != nil {
-				glog.Errorf("Failed to extract ApiMethodOptions from %s.%s: %v", svc.GetName(), md.GetName(), err)
+				log.Errorf("Failed to extract ApiMethodOptions from %s.%s: %v", svc.GetName(), md.GetName(), err)
 				return err
 			}
 			if opts == nil {
-				glog.V(1).Infof("Skip non-target method: %s.%s", svc.GetName(), md.GetName())
+				log.Infof("Skip non-target method: %s.%s", svc.GetName(), md.GetName())
 				continue
 			}
 			meth, err := r.newMethod(svc, md, opts)
@@ -43,7 +43,7 @@ func (r *Registry) loadServices(file *File) error {
 		if len(svc.Methods) == 0 {
 			continue
 		}
-		glog.V(2).Infof("Registered %s with %d method(s)", svc.GetName(), len(svc.Methods))
+		log.Infof("Registered %s with %d method(s)", svc.GetName(), len(svc.Methods))
 		svcs = append(svcs, svc)
 	}
 	file.Services = svcs
@@ -104,7 +104,7 @@ func (r *Registry) newMethod(svc *Service, md *descriptor.MethodDescriptorProto,
 			pathTemplate = custom.Path
 
 		default:
-			glog.Errorf("No pattern specified in google.api.HttpRule: %s", md.GetName())
+			log.Errorf("No pattern specified in google.api.HttpRule: %s", md.GetName())
 			return nil, fmt.Errorf("none of pattern specified")
 		}
 
@@ -251,7 +251,7 @@ func (r *Registry) resolveFiledPath(msg *Message, path string) ([]FieldPathCompo
 			}
 		}
 
-		glog.V(2).Infof("Lookup %s in %s", c, msg.FQMN())
+		log.Infof("Lookup %s in %s", c, msg.FQMN())
 		f := lookupField(msg, c)
 		if f == nil {
 			return nil, fmt.Errorf("no field %q found in %s", path, root.GetName())

--- a/protoc-gen-grpc-gateway/gengateway/generator.go
+++ b/protoc-gen-grpc-gateway/gengateway/generator.go
@@ -8,8 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/gengo/grpc-gateway/log"
 	"github.com/gengo/grpc-gateway/protoc-gen-grpc-gateway/descriptor"
-	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
 	plugin "github.com/golang/protobuf/protoc-gen-go/plugin"
 )
@@ -30,9 +30,9 @@ func New(reg *descriptor.Registry) *generator {
 		"encoding/json",
 		"io",
 		"net/http",
+		"github.com/gengo/grpc-gateway/log",
 		"github.com/gengo/grpc-gateway/runtime",
 		"github.com/gengo/grpc-gateway/utilities",
-		"github.com/golang/glog",
 		"github.com/golang/protobuf/proto",
 		"golang.org/x/net/context",
 		"google.golang.org/grpc",
@@ -60,10 +60,10 @@ func New(reg *descriptor.Registry) *generator {
 func (g *generator) Generate(targets []*descriptor.File) ([]*plugin.CodeGeneratorResponse_File, error) {
 	var files []*plugin.CodeGeneratorResponse_File
 	for _, file := range targets {
-		glog.V(1).Infof("Processing %s", file.GetName())
+		log.Infof("Processing %s", file.GetName())
 		code, err := g.generate(file)
 		if err == errNoTargetService {
-			glog.V(1).Infof("%s: %v", file.GetName(), err)
+			log.Infof("%s: %v", file.GetName(), err)
 			continue
 		}
 		if err != nil {
@@ -71,7 +71,7 @@ func (g *generator) Generate(targets []*descriptor.File) ([]*plugin.CodeGenerato
 		}
 		formatted, err := format.Source([]byte(code))
 		if err != nil {
-			glog.Errorf("%v: %s", err, code)
+			log.Errorf("%v: %s", err, code)
 			return nil, err
 		}
 		name := file.GetName()
@@ -82,7 +82,7 @@ func (g *generator) Generate(targets []*descriptor.File) ([]*plugin.CodeGenerato
 			Name:    proto.String(output),
 			Content: proto.String(string(formatted)),
 		})
-		glog.V(1).Infof("Will emit %s", output)
+		log.Infof("Will emit %s", output)
 	}
 	return files, nil
 }

--- a/protoc-gen-grpc-gateway/httprule/parse.go
+++ b/protoc-gen-grpc-gateway/httprule/parse.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/golang/glog"
+	"github.com/gengo/grpc-gateway/log"
 )
 
 // InvalidTemplateError indicates that the path template is not valid.
@@ -99,16 +99,16 @@ type parser struct {
 
 // topLevelSegments is the target of this parser.
 func (p *parser) topLevelSegments() ([]segment, error) {
-	glog.V(1).Infof("Parsing %q", p.tokens)
+	log.Infof("Parsing %q", p.tokens)
 	segs, err := p.segments()
 	if err != nil {
 		return nil, err
 	}
-	glog.V(2).Infof("accept segments: %q; %q", p.accepted, p.tokens)
+	log.Infof("accept segments: %q; %q", p.accepted, p.tokens)
 	if _, err := p.accept(typeEOF); err != nil {
 		return nil, fmt.Errorf("unexpected token %q after segments %q", p.tokens[0], strings.Join(p.accepted, ""))
 	}
-	glog.V(2).Infof("accept eof: %q; %q", p.accepted, p.tokens)
+	log.Infof("accept eof: %q; %q", p.accepted, p.tokens)
 	return segs, nil
 }
 
@@ -117,7 +117,7 @@ func (p *parser) segments() ([]segment, error) {
 	if err != nil {
 		return nil, err
 	}
-	glog.V(2).Infof("accept segment: %q; %q", p.accepted, p.tokens)
+	log.Infof("accept segment: %q; %q", p.accepted, p.tokens)
 
 	segs := []segment{s}
 	for {
@@ -129,7 +129,7 @@ func (p *parser) segments() ([]segment, error) {
 			return segs, err
 		}
 		segs = append(segs, s)
-		glog.V(2).Infof("accept segment: %q; %q", p.accepted, p.tokens)
+		log.Infof("accept segment: %q; %q", p.accepted, p.tokens)
 	}
 }
 

--- a/protoc-gen-grpc-gateway/httprule/parse_test.go
+++ b/protoc-gen-grpc-gateway/httprule/parse_test.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/golang/glog"
+	"github.com/gengo/grpc-gateway/log"
 )
 
 func TestTokenize(t *testing.T) {
@@ -308,6 +308,6 @@ func TestParseSegmentsWithErrors(t *testing.T) {
 			t.Errorf("parser{%q}.segments() succeeded; want InvalidTemplateError; accepted %#v", spec.tokens, segs)
 			continue
 		}
-		glog.V(1).Info(err)
+		log.Infoln(err)
 	}
 }

--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/golang/glog"
+	"github.com/gengo/grpc-gateway/log"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -50,7 +50,7 @@ func HTTPStatusFromCode(code codes.Code) int {
 		return http.StatusInternalServerError
 	}
 
-	glog.Errorf("Unknown gRPC error code: %v", code)
+	log.Errorf("Unknown gRPC error code: %v", code)
 	return http.StatusInternalServerError
 }
 
@@ -77,10 +77,10 @@ func DefaultHTTPError(ctx context.Context, w http.ResponseWriter, err error) {
 	body := errorBody{Error: err.Error()}
 	buf, merr := json.Marshal(body)
 	if merr != nil {
-		glog.Errorf("Failed to marshal error message %q: %v", body, merr)
+		log.Errorf("Failed to marshal error message %q: %v", body, merr)
 		w.WriteHeader(http.StatusInternalServerError)
 		if _, err := io.WriteString(w, fallback); err != nil {
-			glog.Errorf("Failed to write response: %v", err)
+			log.Errorf("Failed to write response: %v", err)
 		}
 		return
 	}
@@ -88,6 +88,6 @@ func DefaultHTTPError(ctx context.Context, w http.ResponseWriter, err error) {
 	st := HTTPStatusFromCode(grpc.Code(err))
 	w.WriteHeader(st)
 	if _, err := w.Write(buf); err != nil {
-		glog.Errorf("Failed to write response: %v", err)
+		log.Errorf("Failed to write response: %v", err)
 	}
 }

--- a/runtime/mux.go
+++ b/runtime/mux.go
@@ -4,7 +4,8 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/golang/glog"
+	"github.com/gengo/grpc-gateway/log"
+	_ "github.com/gengo/grpc-gateway/log/glog"
 )
 
 // A HandlerFunc handles a specific pair of path pattern and HTTP method.
@@ -58,7 +59,7 @@ func (s *ServeMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	for _, h := range s.handlers[r.Method] {
 		pathParams, err := h.pat.Match(components, verb)
 		if err != nil {
-			glog.V(3).Infof("path mismatch: %q to %q", path, h.pat)
+			log.Infof("path mismatch: %q to %q", path, h.pat)
 			continue
 		}
 		h.h(w, r, pathParams)

--- a/runtime/pattern.go
+++ b/runtime/pattern.go
@@ -3,10 +3,11 @@ package runtime
 import (
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 
+	"github.com/gengo/grpc-gateway/log"
 	"github.com/gengo/grpc-gateway/utilities"
-	"github.com/golang/glog"
 )
 
 var (
@@ -44,13 +45,13 @@ type Pattern struct {
 // It returns an error if the given definition is invalid.
 func NewPattern(version int, ops []int, pool []string, verb string) (Pattern, error) {
 	if version != 1 {
-		glog.V(2).Infof("unsupported version: %d", version)
+		log.Infof("unsupported version: %d", version)
 		return Pattern{}, ErrInvalidPattern
 	}
 
 	l := len(ops)
 	if l%2 != 0 {
-		glog.V(2).Infof("odd number of ops codes: %d", l)
+		log.Infof("odd number of ops codes: %d", l)
 		return Pattern{}, ErrInvalidPattern
 	}
 
@@ -73,14 +74,14 @@ func NewPattern(version int, ops []int, pool []string, verb string) (Pattern, er
 			stack++
 		case utilities.OpPushM:
 			if pushMSeen {
-				glog.V(2).Info("pushM appears twice")
+				log.Infoln("pushM appears twice")
 				return Pattern{}, ErrInvalidPattern
 			}
 			pushMSeen = true
 			stack++
 		case utilities.OpLitPush:
 			if op.operand < 0 || len(pool) <= op.operand {
-				glog.V(2).Infof("negative literal index: %d", op.operand)
+				log.Infof("negative literal index: %d", op.operand)
 				return Pattern{}, ErrInvalidPattern
 			}
 			if pushMSeen {
@@ -89,18 +90,18 @@ func NewPattern(version int, ops []int, pool []string, verb string) (Pattern, er
 			stack++
 		case utilities.OpConcatN:
 			if op.operand <= 0 {
-				glog.V(2).Infof("negative concat size: %d", op.operand)
+				log.Infof("negative concat size: %d", op.operand)
 				return Pattern{}, ErrInvalidPattern
 			}
 			stack -= op.operand
 			if stack < 0 {
-				glog.V(2).Info("stack underflow")
+				log.Infoln("stack underflow")
 				return Pattern{}, ErrInvalidPattern
 			}
 			stack++
 		case utilities.OpCapture:
 			if op.operand < 0 || len(pool) <= op.operand {
-				glog.V(2).Infof("variable name index out of bound: %d", op.operand)
+				log.Infof("variable name index out of bound: %d", op.operand)
 				return Pattern{}, ErrInvalidPattern
 			}
 			v := pool[op.operand]
@@ -108,11 +109,11 @@ func NewPattern(version int, ops []int, pool []string, verb string) (Pattern, er
 			vars = append(vars, v)
 			stack--
 			if stack < 0 {
-				glog.V(2).Info("stack underflow")
+				log.Infoln("stack underflow")
 				return Pattern{}, ErrInvalidPattern
 			}
 		default:
-			glog.V(2).Infof("invalid opcode: %d", op.code)
+			log.Infof("invalid opcode: %d", op.code)
 			return Pattern{}, ErrInvalidPattern
 		}
 
@@ -121,7 +122,7 @@ func NewPattern(version int, ops []int, pool []string, verb string) (Pattern, er
 		}
 		typedOps = append(typedOps, op)
 	}
-	glog.V(3).Info("pattern successfully built")
+	log.Infoln("pattern successfully built")
 	return Pattern{
 		ops:       typedOps,
 		pool:      pool,
@@ -135,7 +136,8 @@ func NewPattern(version int, ops []int, pool []string, verb string) (Pattern, er
 // MustPattern is a helper function which makes it easier to call NewPattern in variable initialization.
 func MustPattern(p Pattern, err error) Pattern {
 	if err != nil {
-		glog.Fatalf("Pattern initialization failed: %v", err)
+		log.Errorf("Pattern initialization failed: %v", err)
+		os.Exit(1)
 	}
 	return p
 }
@@ -144,7 +146,7 @@ func MustPattern(p Pattern, err error) Pattern {
 // If it matches, the function returns a mapping from field paths to their captured values.
 // If otherwise, the function returns an error.
 func (p Pattern) Match(components []string, verb string) (map[string]string, error) {
-	glog.V(2).Infof("matching (%q, %q) to %v", components, verb, p)
+	log.Infof("matching (%q, %q) to %v", components, verb, p)
 
 	if p.verb != verb {
 		return nil, ErrNotMatch
@@ -160,13 +162,13 @@ func (p Pattern) Match(components []string, verb string) (map[string]string, err
 			continue
 		case utilities.OpPush, utilities.OpLitPush:
 			if pos >= l {
-				glog.V(1).Infof("insufficient # of segments")
+				log.Infof("insufficient # of segments")
 				return nil, ErrNotMatch
 			}
 			c := components[pos]
 			if op.code == utilities.OpLitPush {
 				if lit := p.pool[op.operand]; c != lit {
-					glog.V(1).Infof("literal segment mismatch: got %q; want %q", c, lit)
+					log.Infof("literal segment mismatch: got %q; want %q", c, lit)
 					return nil, ErrNotMatch
 				}
 			}
@@ -191,7 +193,7 @@ func (p Pattern) Match(components []string, verb string) (map[string]string, err
 		}
 	}
 	if pos < l {
-		glog.V(1).Infof("remaining segments: %q", components[pos:])
+		log.Infof("remaining segments: %q", components[pos:])
 		return nil, ErrNotMatch
 	}
 	bindings := make(map[string]string)

--- a/runtime/query.go
+++ b/runtime/query.go
@@ -6,8 +6,8 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/gengo/grpc-gateway/log"
 	"github.com/gengo/grpc-gateway/utilities"
-	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
 )
 
@@ -46,7 +46,7 @@ func populateFieldValueFromPath(msg proto.Message, fieldPath []string, values []
 		}
 		f := m.FieldByName(utilities.PascalFromSnake(fieldName))
 		if !f.IsValid() {
-			glog.Warningf("field not found in %T: %s", msg, strings.Join(fieldPath, "."))
+			log.Warnf("field not found in %T: %s", msg, strings.Join(fieldPath, "."))
 			return nil
 		}
 
@@ -78,7 +78,7 @@ func populateFieldValueFromPath(msg proto.Message, fieldPath []string, values []
 		return fmt.Errorf("no value of field: %s", strings.Join(fieldPath, "."))
 	case 1:
 	default:
-		glog.Warningf("too many field values: %s", strings.Join(fieldPath, "."))
+		log.Warnf("too many field values: %s", strings.Join(fieldPath, "."))
 	}
 	return populateField(m, values[0])
 }


### PR DESCRIPTION
This is probably not ready to merge (but does pass tests), but is more for discussion as to what to do here.

I generally use other log implementations than glog, and others do too. It is nice to be able to choose an alternative logger, so I added a simple interface here for a Logger that takes care of most functionality. Instead of the V system that glog has, if you like this direction, I can add Debugf/Debugln to somewhat take care of that situation.

The package github.com/gengo/grpc-gateway is currently imported in runtime/mux.go, so that glog is still the default. Probably not the best place for this (again, this PR probably needs work, but wanted initial feedback).

Reason for doing *ln: all logging generally does newlines anyways, or handles newlines, so it makes more sense to me. Also this means that my https://github.com/peter-edge/go-protolog/blob/master/protolog.go#L59 Logger is a drop-in, which is what I want to use this for anyways :)

I did a similar thing for https://github.com/grpc/grpc-go in https://github.com/grpc/grpc-go/tree/master/grpclog