### PR TITLE
Fix `error` field always in chunk response

### DIFF
--- a/runtime/handler.go
+++ b/runtime/handler.go
@@ -14,7 +14,7 @@ import (
 
 type responseStreamChunk struct {
 	Result proto.Message       `json:"result,omitempty"`
-	Error  responseStreamError `json:"error,omitempty"`
+	Error  *responseStreamError `json:"error,omitempty"`
 }
 
 type responseStreamError struct {
@@ -103,7 +103,7 @@ func handleForwardResponseOptions(ctx context.Context, w http.ResponseWriter, re
 func handleForwardResponseStreamError(w http.ResponseWriter, err error) {
 	grpcCode := grpc.Code(err)
 	httpCode := HTTPStatusFromCode(grpcCode)
-	resp := responseStreamChunk{Error: responseStreamError{GrpcCode: int(grpcCode),
+	resp := responseStreamChunk{Error: &responseStreamError{GrpcCode: int(grpcCode),
 		HTTPCode:   httpCode,
 		Message:    err.Error(),
 		HTTPStatus: http.StatusText(httpCode)}}


### PR DESCRIPTION
Because the `responseStreamError` was an embedded object and not a pointer, it was always added to the response (the `omitempty` didn't work).

Moving it to be a pointer solves the problem and makes good results always have only `result` field, while errors only have the `error` field.