### PR TITLE
Add WithValidateRequestOption to offer external validation on requests

### DIFF
--- a/protoc-gen-grpc-gateway/gengateway/template.go
+++ b/protoc-gen-grpc-gateway/gengateway/template.go
@@ -245,6 +245,9 @@ func Register{{$svc.GetName}}Handler(ctx context.Context, mux *runtime.ServeMux,
 	{{range $m := $svc.Methods}}
 	{{range $b := $m.Bindings}}
 	mux.Handle({{$b.HTTPMethod | printf "%q"}}, pattern_{{$svc.GetName}}_{{$m.GetName}}_{{$b.Index}}, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		if !runtime.HandleRequestValidateOptions({{$m.GetName | printf "%q"}}, ctx, w, req, pathParams, mux.GetValidateRequestOptions()) {
+			return
+		}
 		resp, err := request_{{$svc.GetName}}_{{$m.GetName}}_{{$b.Index}}(runtime.AnnotateContext(ctx, req), client, req, pathParams)
 		if err != nil {
 			runtime.HTTPError(ctx, w, err)

--- a/runtime/handler.go
+++ b/runtime/handler.go
@@ -87,6 +87,16 @@ func ForwardResponseMessage(ctx context.Context, w http.ResponseWriter, req *htt
 	}
 }
 
+// HandleRequestValidateOptions will run all request validation options before parsing the request and accessing the gRPC server.
+func HandleRequestValidateOptions(methodName string, ctx context.Context, w http.ResponseWriter, r *http.Request, pathParams map[string]string, opts []ValidateRequestHandlerFunc) bool {
+	for _, opt := range opts {
+		if !opt(methodName, ctx, w, r, pathParams) {
+			return false
+		}
+	}
+	return true
+}
+
 func handleForwardResponseOptions(ctx context.Context, w http.ResponseWriter, resp proto.Message, opts []func(context.Context, http.ResponseWriter, proto.Message) error) error {
 	if len(opts) == 0 {
 		return nil


### PR DESCRIPTION
Use-case: add CORS support for example, or extra validation/redirects for some requests. I am practically going to use this for the former but I can see it can be used for other purposes too.

It's a bit like the forward options, but runs before anything else as you can see from the template changes; this is also a cheap middleware solution.