### PR TITLE
Added missing instruction line in README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ First you need to install ProtocolBuffers 3.0 or later.
 mkdir tmp
 cd tmp
 git clone https://github.com/google/protobuf
+cd protobuf
 ./autogen.sh
 ./configure
 make


### PR DESCRIPTION
...under Installation of ProtocolBuffers.
It's just a one-liner. :-) 