### PR TITLE
Add abstraction of code generator implementation

### DIFF
--- a/protoc-gen-grpc-gateway/generator/generator.go
+++ b/protoc-gen-grpc-gateway/generator/generator.go
@@ -1,0 +1,13 @@
+// Package generator provides an abstract interface to code generators.
+package generator
+
+import (
+	"github.com/gengo/grpc-gateway/protoc-gen-grpc-gateway/descriptor"
+	plugin "github.com/golang/protobuf/protoc-gen-go/plugin"
+)
+
+// Generator is an abstraction of code generators.
+type Generator interface {
+	// Generate generates output files from input .proto files.
+	Generate(targets []*descriptor.File) ([]*plugin.CodeGeneratorResponse_File, error)
+}

--- a/protoc-gen-grpc-gateway/gengateway/generator.go
+++ b/protoc-gen-grpc-gateway/gengateway/generator.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/gengo/grpc-gateway/protoc-gen-grpc-gateway/descriptor"
+	gen "github.com/gengo/grpc-gateway/protoc-gen-grpc-gateway/generator"
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
 	plugin "github.com/golang/protobuf/protoc-gen-go/plugin"
@@ -24,7 +25,7 @@ type generator struct {
 }
 
 // New returns a new generator which generates grpc gateway files.
-func New(reg *descriptor.Registry) *generator {
+func New(reg *descriptor.Registry) gen.Generator {
 	var imports []descriptor.GoPackage
 	for _, pkgpath := range []string{
 		"encoding/json",


### PR DESCRIPTION
It helps us to add more types of code generators.

It also fixes a golint error:
> exported func New returns unexported type *gengateway.generator, which
> can be annoying to use