### PR TITLE
make grpc.DialOption configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Make sure that your `$GOPATH/bin` is in your `$PATH`.
      "github.com/golang/glog"
      "golang.org/x/net/context"
      "github.com/gengo/grpc-gateway/runtime"
+     "google.golang.org/grpc"
    	
      gw "path/to/your_service_package"
    )
@@ -147,7 +148,8 @@ Make sure that your `$GOPATH/bin` is in your `$PATH`.
      defer cancel()
    
      mux := runtime.NewServeMux()
-     err := gw.RegisterYourServiceHandlerFromEndpoint(ctx, mux, *echoEndpoint)
+     opts := []grpc.DialOption{grpc.WithInsecure()}
+     err := gw.RegisterYourServiceHandlerFromEndpoint(ctx, mux, *echoEndpoint, opts)
      if err != nil {
        return err
      }

--- a/examples/examplepb/a_bit_of_everything.pb.gw.go
+++ b/examples/examplepb/a_bit_of_everything.pb.gw.go
@@ -405,8 +405,8 @@ func request_ABitOfEverythingService_BulkEcho_0(ctx context.Context, client ABit
 
 // RegisterABitOfEverythingServiceHandlerFromEndpoint is same as RegisterABitOfEverythingServiceHandler but
 // automatically dials to "endpoint" and closes the connection when "ctx" gets done.
-func RegisterABitOfEverythingServiceHandlerFromEndpoint(ctx context.Context, mux *runtime.ServeMux, endpoint string) (err error) {
-	conn, err := grpc.Dial(endpoint, grpc.WithInsecure())
+func RegisterABitOfEverythingServiceHandlerFromEndpoint(ctx context.Context, mux *runtime.ServeMux, endpoint string, opts []grpc.DialOption) (err error) {
+	conn, err := grpc.Dial(endpoint, opts...)
 	if err != nil {
 		return err
 	}

--- a/examples/examplepb/echo_service.pb.gw.go
+++ b/examples/examplepb/echo_service.pb.gw.go
@@ -65,8 +65,8 @@ func request_EchoService_EchoBody_0(ctx context.Context, client EchoServiceClien
 
 // RegisterEchoServiceHandlerFromEndpoint is same as RegisterEchoServiceHandler but
 // automatically dials to "endpoint" and closes the connection when "ctx" gets done.
-func RegisterEchoServiceHandlerFromEndpoint(ctx context.Context, mux *runtime.ServeMux, endpoint string) (err error) {
-	conn, err := grpc.Dial(endpoint, grpc.WithInsecure())
+func RegisterEchoServiceHandlerFromEndpoint(ctx context.Context, mux *runtime.ServeMux, endpoint string, opts []grpc.DialOption) (err error) {
+	conn, err := grpc.Dial(endpoint, opts...)
 	if err != nil {
 		return err
 	}

--- a/examples/examplepb/flow_combination.pb.gw.go
+++ b/examples/examplepb/flow_combination.pb.gw.go
@@ -785,8 +785,8 @@ func request_FlowCombination_RpcPathNestedStream_2(ctx context.Context, client F
 
 // RegisterFlowCombinationHandlerFromEndpoint is same as RegisterFlowCombinationHandler but
 // automatically dials to "endpoint" and closes the connection when "ctx" gets done.
-func RegisterFlowCombinationHandlerFromEndpoint(ctx context.Context, mux *runtime.ServeMux, endpoint string) (err error) {
-	conn, err := grpc.Dial(endpoint, grpc.WithInsecure())
+func RegisterFlowCombinationHandlerFromEndpoint(ctx context.Context, mux *runtime.ServeMux, endpoint string, opts []grpc.DialOption) (err error) {
+	conn, err := grpc.Dial(endpoint, opts...)
 	if err != nil {
 		return err
 	}

--- a/examples/main.go
+++ b/examples/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gengo/grpc-gateway/runtime"
 	"github.com/golang/glog"
 	"golang.org/x/net/context"
+	"google.golang.org/grpc"
 )
 
 var (
@@ -22,15 +23,16 @@ func Run(address string, opts ...runtime.ServeMuxOption) error {
 	defer cancel()
 
 	mux := runtime.NewServeMux(opts...)
-	err := examplepb.RegisterEchoServiceHandlerFromEndpoint(ctx, mux, *echoEndpoint)
+	dialOpts := []grpc.DialOption{grpc.WithInsecure()}
+	err := examplepb.RegisterEchoServiceHandlerFromEndpoint(ctx, mux, *echoEndpoint, dialOpts)
 	if err != nil {
 		return err
 	}
-	err = examplepb.RegisterABitOfEverythingServiceHandlerFromEndpoint(ctx, mux, *abeEndpoint)
+	err = examplepb.RegisterABitOfEverythingServiceHandlerFromEndpoint(ctx, mux, *abeEndpoint, dialOpts)
 	if err != nil {
 		return err
 	}
-	err = examplepb.RegisterFlowCombinationHandlerFromEndpoint(ctx, mux, *flowEndpoint)
+	err = examplepb.RegisterFlowCombinationHandlerFromEndpoint(ctx, mux, *flowEndpoint, dialOpts)
 	if err != nil {
 		return err
 	}

--- a/protoc-gen-grpc-gateway/gengateway/template.go
+++ b/protoc-gen-grpc-gateway/gengateway/template.go
@@ -215,8 +215,8 @@ var (
 {{range $svc := .}}
 // Register{{$svc.GetName}}HandlerFromEndpoint is same as Register{{$svc.GetName}}Handler but
 // automatically dials to "endpoint" and closes the connection when "ctx" gets done.
-func Register{{$svc.GetName}}HandlerFromEndpoint(ctx context.Context, mux *runtime.ServeMux, endpoint string) (err error) {
-	conn, err := grpc.Dial(endpoint, grpc.WithInsecure())
+func Register{{$svc.GetName}}HandlerFromEndpoint(ctx context.Context, mux *runtime.ServeMux, endpoint string, opts []grpc.DialOption) (err error) {
+	conn, err := grpc.Dial(endpoint, opts...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
`grpc.WithInsecure()` is used implicitly as `grpc.DialOptions` currently. When TLS is enabled at gRPC server, we have to use `grpc.WithTransportCredentials(creds)`.
This patch makes `grpc.DialOption` configurable by passing options  via args of `RegisterXXXHandlerFromEndpoint`.

NOTE: this is an interface change of public method.