### PR TITLE
make available header and trailer metadata

### DIFF
--- a/examples/examplepb/a_bit_of_everything.pb.gw.go
+++ b/examples/examplepb/a_bit_of_everything.pb.gw.go
@@ -500,7 +500,7 @@ func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.Se
 			}()
 		}
 		resp, md, err := request_ABitOfEverythingService_Create_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
-		ctx = runtime.NewServerMetadataContext(ctx, &md)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -520,7 +520,7 @@ func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.Se
 			}()
 		}
 		resp, md, err := request_ABitOfEverythingService_CreateBody_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
-		ctx = runtime.NewServerMetadataContext(ctx, &md)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -540,7 +540,7 @@ func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.Se
 			}()
 		}
 		resp, md, err := request_ABitOfEverythingService_BulkCreate_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
-		ctx = runtime.NewServerMetadataContext(ctx, &md)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -560,7 +560,7 @@ func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.Se
 			}()
 		}
 		resp, md, err := request_ABitOfEverythingService_Lookup_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
-		ctx = runtime.NewServerMetadataContext(ctx, &md)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -580,7 +580,7 @@ func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.Se
 			}()
 		}
 		resp, md, err := request_ABitOfEverythingService_List_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
-		ctx = runtime.NewServerMetadataContext(ctx, &md)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -600,7 +600,7 @@ func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.Se
 			}()
 		}
 		resp, md, err := request_ABitOfEverythingService_Update_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
-		ctx = runtime.NewServerMetadataContext(ctx, &md)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -620,7 +620,7 @@ func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.Se
 			}()
 		}
 		resp, md, err := request_ABitOfEverythingService_Delete_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
-		ctx = runtime.NewServerMetadataContext(ctx, &md)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -640,7 +640,7 @@ func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.Se
 			}()
 		}
 		resp, md, err := request_ABitOfEverythingService_Echo_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
-		ctx = runtime.NewServerMetadataContext(ctx, &md)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -660,7 +660,7 @@ func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.Se
 			}()
 		}
 		resp, md, err := request_ABitOfEverythingService_Echo_1(runtime.AnnotateContext(ctx, req), client, req, pathParams)
-		ctx = runtime.NewServerMetadataContext(ctx, &md)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -680,7 +680,7 @@ func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.Se
 			}()
 		}
 		resp, md, err := request_ABitOfEverythingService_Echo_2(runtime.AnnotateContext(ctx, req), client, req, pathParams)
-		ctx = runtime.NewServerMetadataContext(ctx, &md)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -700,7 +700,7 @@ func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.Se
 			}()
 		}
 		resp, md, err := request_ABitOfEverythingService_BulkEcho_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
-		ctx = runtime.NewServerMetadataContext(ctx, &md)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return

--- a/examples/examplepb/a_bit_of_everything.pb.gw.go
+++ b/examples/examplepb/a_bit_of_everything.pb.gw.go
@@ -34,8 +34,9 @@ var (
 	filter_ABitOfEverythingService_Create_0 = &utilities.DoubleArray{Encoding: map[string]int{"float_value": 0, "double_value": 1, "int64_value": 2, "uint64_value": 3, "int32_value": 4, "fixed64_value": 5, "fixed32_value": 6, "bool_value": 7, "string_value": 8, "uint32_value": 9, "sfixed32_value": 10, "sfixed64_value": 11, "sint32_value": 12, "sint64_value": 13}, Base: []int{1, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, Check: []int{0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}}
 )
 
-func request_ABitOfEverythingService_Create_0(ctx context.Context, client ABitOfEverythingServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, error) {
+func request_ABitOfEverythingService_Create_0(ctx context.Context, client ABitOfEverythingServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq ABitOfEverything
+	var metadata runtime.ServerMetadata
 
 	var (
 		val string
@@ -46,180 +47,186 @@ func request_ABitOfEverythingService_Create_0(ctx context.Context, client ABitOf
 
 	val, ok = pathParams["float_value"]
 	if !ok {
-		return nil, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "float_value")
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "float_value")
 	}
 
 	protoReq.FloatValue, err = runtime.Float32(val)
 
 	if err != nil {
-		return nil, err
+		return nil, metadata, err
 	}
 
 	val, ok = pathParams["double_value"]
 	if !ok {
-		return nil, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "double_value")
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "double_value")
 	}
 
 	protoReq.DoubleValue, err = runtime.Float64(val)
 
 	if err != nil {
-		return nil, err
+		return nil, metadata, err
 	}
 
 	val, ok = pathParams["int64_value"]
 	if !ok {
-		return nil, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "int64_value")
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "int64_value")
 	}
 
 	protoReq.Int64Value, err = runtime.Int64(val)
 
 	if err != nil {
-		return nil, err
+		return nil, metadata, err
 	}
 
 	val, ok = pathParams["uint64_value"]
 	if !ok {
-		return nil, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "uint64_value")
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "uint64_value")
 	}
 
 	protoReq.Uint64Value, err = runtime.Uint64(val)
 
 	if err != nil {
-		return nil, err
+		return nil, metadata, err
 	}
 
 	val, ok = pathParams["int32_value"]
 	if !ok {
-		return nil, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "int32_value")
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "int32_value")
 	}
 
 	protoReq.Int32Value, err = runtime.Int32(val)
 
 	if err != nil {
-		return nil, err
+		return nil, metadata, err
 	}
 
 	val, ok = pathParams["fixed64_value"]
 	if !ok {
-		return nil, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "fixed64_value")
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "fixed64_value")
 	}
 
 	protoReq.Fixed64Value, err = runtime.Uint64(val)
 
 	if err != nil {
-		return nil, err
+		return nil, metadata, err
 	}
 
 	val, ok = pathParams["fixed32_value"]
 	if !ok {
-		return nil, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "fixed32_value")
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "fixed32_value")
 	}
 
 	protoReq.Fixed32Value, err = runtime.Uint32(val)
 
 	if err != nil {
-		return nil, err
+		return nil, metadata, err
 	}
 
 	val, ok = pathParams["bool_value"]
 	if !ok {
-		return nil, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "bool_value")
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "bool_value")
 	}
 
 	protoReq.BoolValue, err = runtime.Bool(val)
 
 	if err != nil {
-		return nil, err
+		return nil, metadata, err
 	}
 
 	val, ok = pathParams["string_value"]
 	if !ok {
-		return nil, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "string_value")
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "string_value")
 	}
 
 	protoReq.StringValue, err = runtime.String(val)
 
 	if err != nil {
-		return nil, err
+		return nil, metadata, err
 	}
 
 	val, ok = pathParams["uint32_value"]
 	if !ok {
-		return nil, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "uint32_value")
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "uint32_value")
 	}
 
 	protoReq.Uint32Value, err = runtime.Uint32(val)
 
 	if err != nil {
-		return nil, err
+		return nil, metadata, err
 	}
 
 	val, ok = pathParams["sfixed32_value"]
 	if !ok {
-		return nil, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "sfixed32_value")
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "sfixed32_value")
 	}
 
 	protoReq.Sfixed32Value, err = runtime.Int32(val)
 
 	if err != nil {
-		return nil, err
+		return nil, metadata, err
 	}
 
 	val, ok = pathParams["sfixed64_value"]
 	if !ok {
-		return nil, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "sfixed64_value")
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "sfixed64_value")
 	}
 
 	protoReq.Sfixed64Value, err = runtime.Int64(val)
 
 	if err != nil {
-		return nil, err
+		return nil, metadata, err
 	}
 
 	val, ok = pathParams["sint32_value"]
 	if !ok {
-		return nil, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "sint32_value")
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "sint32_value")
 	}
 
 	protoReq.Sint32Value, err = runtime.Int32(val)
 
 	if err != nil {
-		return nil, err
+		return nil, metadata, err
 	}
 
 	val, ok = pathParams["sint64_value"]
 	if !ok {
-		return nil, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "sint64_value")
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "sint64_value")
 	}
 
 	protoReq.Sint64Value, err = runtime.Int64(val)
 
 	if err != nil {
-		return nil, err
+		return nil, metadata, err
 	}
 
 	if err := runtime.PopulateQueryParameters(&protoReq, req.URL.Query(), filter_ABitOfEverythingService_Create_0); err != nil {
-		return nil, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
-	return client.Create(ctx, &protoReq)
+	msg, err := client.Create(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
 }
 
-func request_ABitOfEverythingService_CreateBody_0(ctx context.Context, client ABitOfEverythingServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, error) {
+func request_ABitOfEverythingService_CreateBody_0(ctx context.Context, client ABitOfEverythingServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq ABitOfEverything
+	var metadata runtime.ServerMetadata
 
 	if err := json.NewDecoder(req.Body).Decode(&protoReq); err != nil {
-		return nil, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
-	return client.CreateBody(ctx, &protoReq)
+	msg, err := client.CreateBody(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
 }
 
-func request_ABitOfEverythingService_BulkCreate_0(ctx context.Context, client ABitOfEverythingServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, error) {
+func request_ABitOfEverythingService_BulkCreate_0(ctx context.Context, client ABitOfEverythingServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var metadata runtime.ServerMetadata
 	stream, err := client.BulkCreate(ctx)
 	if err != nil {
 		glog.Errorf("Failed to start streaming: %v", err)
-		return nil, err
+		return nil, metadata, err
 	}
 	dec := json.NewDecoder(req.Body)
 	for {
@@ -230,20 +237,34 @@ func request_ABitOfEverythingService_BulkCreate_0(ctx context.Context, client AB
 		}
 		if err != nil {
 			glog.Errorf("Failed to decode request: %v", err)
-			return nil, grpc.Errorf(codes.InvalidArgument, "%v", err)
+			return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
 		}
 		if err = stream.Send(&protoReq); err != nil {
 			glog.Errorf("Failed to send request: %v", err)
-			return nil, err
+			return nil, metadata, err
 		}
 	}
 
-	return stream.CloseAndRecv()
+	if err := stream.CloseSend(); err != nil {
+		glog.Errorf("Failed to terminate client stream: %v", err)
+		return nil, metadata, err
+	}
+	header, err := stream.Header()
+	if err != nil {
+		glog.Errorf("Failed to get header from client: %v", err)
+		return nil, metadata, err
+	}
+	metadata.HeaderMD = header
+
+	msg, err := stream.CloseAndRecv()
+	metadata.TrailerMD = stream.Trailer()
+	return msg, metadata, err
 
 }
 
-func request_ABitOfEverythingService_Lookup_0(ctx context.Context, client ABitOfEverythingServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, error) {
+func request_ABitOfEverythingService_Lookup_0(ctx context.Context, client ABitOfEverythingServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq IdMessage
+	var metadata runtime.ServerMetadata
 
 	var (
 		val string
@@ -254,29 +275,43 @@ func request_ABitOfEverythingService_Lookup_0(ctx context.Context, client ABitOf
 
 	val, ok = pathParams["uuid"]
 	if !ok {
-		return nil, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "uuid")
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "uuid")
 	}
 
 	protoReq.Uuid, err = runtime.String(val)
 
 	if err != nil {
-		return nil, err
+		return nil, metadata, err
 	}
 
-	return client.Lookup(ctx, &protoReq)
+	msg, err := client.Lookup(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
 }
 
-func request_ABitOfEverythingService_List_0(ctx context.Context, client ABitOfEverythingServiceClient, req *http.Request, pathParams map[string]string) (ABitOfEverythingService_ListClient, error) {
+func request_ABitOfEverythingService_List_0(ctx context.Context, client ABitOfEverythingServiceClient, req *http.Request, pathParams map[string]string) (ABitOfEverythingService_ListClient, runtime.ServerMetadata, error) {
 	var protoReq EmptyMessage
+	var metadata runtime.ServerMetadata
 
-	return client.List(ctx, &protoReq)
+	stream, err := client.List(ctx, &protoReq)
+	if err != nil {
+		return nil, metadata, err
+	}
+	header, err := stream.Header()
+	if err != nil {
+		return nil, metadata, err
+	}
+	metadata.HeaderMD = header
+	return stream, metadata, nil
+
 }
 
-func request_ABitOfEverythingService_Update_0(ctx context.Context, client ABitOfEverythingServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, error) {
+func request_ABitOfEverythingService_Update_0(ctx context.Context, client ABitOfEverythingServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq ABitOfEverything
+	var metadata runtime.ServerMetadata
 
 	if err := json.NewDecoder(req.Body).Decode(&protoReq); err != nil {
-		return nil, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	var (
@@ -288,20 +323,23 @@ func request_ABitOfEverythingService_Update_0(ctx context.Context, client ABitOf
 
 	val, ok = pathParams["uuid"]
 	if !ok {
-		return nil, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "uuid")
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "uuid")
 	}
 
 	protoReq.Uuid, err = runtime.String(val)
 
 	if err != nil {
-		return nil, err
+		return nil, metadata, err
 	}
 
-	return client.Update(ctx, &protoReq)
+	msg, err := client.Update(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
 }
 
-func request_ABitOfEverythingService_Delete_0(ctx context.Context, client ABitOfEverythingServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, error) {
+func request_ABitOfEverythingService_Delete_0(ctx context.Context, client ABitOfEverythingServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq IdMessage
+	var metadata runtime.ServerMetadata
 
 	var (
 		val string
@@ -312,20 +350,23 @@ func request_ABitOfEverythingService_Delete_0(ctx context.Context, client ABitOf
 
 	val, ok = pathParams["uuid"]
 	if !ok {
-		return nil, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "uuid")
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "uuid")
 	}
 
 	protoReq.Uuid, err = runtime.String(val)
 
 	if err != nil {
-		return nil, err
+		return nil, metadata, err
 	}
 
-	return client.Delete(ctx, &protoReq)
+	msg, err := client.Delete(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
 }
 
-func request_ABitOfEverythingService_Echo_0(ctx context.Context, client ABitOfEverythingServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, error) {
+func request_ABitOfEverythingService_Echo_0(ctx context.Context, client ABitOfEverythingServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq sub.StringMessage
+	var metadata runtime.ServerMetadata
 
 	var (
 		val string
@@ -336,47 +377,56 @@ func request_ABitOfEverythingService_Echo_0(ctx context.Context, client ABitOfEv
 
 	val, ok = pathParams["value"]
 	if !ok {
-		return nil, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "value")
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "value")
 	}
 
 	protoReq.Value, err = runtime.StringP(val)
 
 	if err != nil {
-		return nil, err
+		return nil, metadata, err
 	}
 
-	return client.Echo(ctx, &protoReq)
+	msg, err := client.Echo(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
 }
 
-func request_ABitOfEverythingService_Echo_1(ctx context.Context, client ABitOfEverythingServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, error) {
+func request_ABitOfEverythingService_Echo_1(ctx context.Context, client ABitOfEverythingServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq sub.StringMessage
+	var metadata runtime.ServerMetadata
 
 	if err := json.NewDecoder(req.Body).Decode(&protoReq.Value); err != nil {
-		return nil, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
-	return client.Echo(ctx, &protoReq)
+	msg, err := client.Echo(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
 }
 
 var (
 	filter_ABitOfEverythingService_Echo_2 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
 )
 
-func request_ABitOfEverythingService_Echo_2(ctx context.Context, client ABitOfEverythingServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, error) {
+func request_ABitOfEverythingService_Echo_2(ctx context.Context, client ABitOfEverythingServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq sub.StringMessage
+	var metadata runtime.ServerMetadata
 
 	if err := runtime.PopulateQueryParameters(&protoReq, req.URL.Query(), filter_ABitOfEverythingService_Echo_2); err != nil {
-		return nil, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
-	return client.Echo(ctx, &protoReq)
+	msg, err := client.Echo(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
 }
 
-func request_ABitOfEverythingService_BulkEcho_0(ctx context.Context, client ABitOfEverythingServiceClient, req *http.Request, pathParams map[string]string) (ABitOfEverythingService_BulkEchoClient, error) {
+func request_ABitOfEverythingService_BulkEcho_0(ctx context.Context, client ABitOfEverythingServiceClient, req *http.Request, pathParams map[string]string) (ABitOfEverythingService_BulkEchoClient, runtime.ServerMetadata, error) {
+	var metadata runtime.ServerMetadata
 	stream, err := client.BulkEcho(ctx)
 	if err != nil {
 		glog.Errorf("Failed to start streaming: %v", err)
-		return nil, err
+		return nil, metadata, err
 	}
 	dec := json.NewDecoder(req.Body)
 	for {
@@ -387,19 +437,26 @@ func request_ABitOfEverythingService_BulkEcho_0(ctx context.Context, client ABit
 		}
 		if err != nil {
 			glog.Errorf("Failed to decode request: %v", err)
-			return nil, grpc.Errorf(codes.InvalidArgument, "%v", err)
+			return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
 		}
 		if err = stream.Send(&protoReq); err != nil {
 			glog.Errorf("Failed to send request: %v", err)
-			return nil, err
+			return nil, metadata, err
 		}
 	}
 
-	if err = stream.CloseSend(); err != nil {
+	if err := stream.CloseSend(); err != nil {
 		glog.Errorf("Failed to terminate client stream: %v", err)
-		return nil, err
+		return nil, metadata, err
 	}
-	return stream, nil
+	header, err := stream.Header()
+	if err != nil {
+		glog.Errorf("Failed to get header from client: %v", err)
+		return nil, metadata, err
+	}
+	metadata.HeaderMD = header
+
+	return stream, metadata, nil
 
 }
 
@@ -442,7 +499,8 @@ func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.Se
 				cancel()
 			}()
 		}
-		resp, err := request_ABitOfEverythingService_Create_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		resp, md, err := request_ABitOfEverythingService_Create_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, &md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -461,7 +519,8 @@ func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.Se
 				cancel()
 			}()
 		}
-		resp, err := request_ABitOfEverythingService_CreateBody_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		resp, md, err := request_ABitOfEverythingService_CreateBody_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, &md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -480,7 +539,8 @@ func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.Se
 				cancel()
 			}()
 		}
-		resp, err := request_ABitOfEverythingService_BulkCreate_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		resp, md, err := request_ABitOfEverythingService_BulkCreate_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, &md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -499,7 +559,8 @@ func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.Se
 				cancel()
 			}()
 		}
-		resp, err := request_ABitOfEverythingService_Lookup_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		resp, md, err := request_ABitOfEverythingService_Lookup_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, &md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -518,7 +579,8 @@ func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.Se
 				cancel()
 			}()
 		}
-		resp, err := request_ABitOfEverythingService_List_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		resp, md, err := request_ABitOfEverythingService_List_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, &md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -537,7 +599,8 @@ func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.Se
 				cancel()
 			}()
 		}
-		resp, err := request_ABitOfEverythingService_Update_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		resp, md, err := request_ABitOfEverythingService_Update_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, &md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -556,7 +619,8 @@ func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.Se
 				cancel()
 			}()
 		}
-		resp, err := request_ABitOfEverythingService_Delete_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		resp, md, err := request_ABitOfEverythingService_Delete_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, &md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -575,7 +639,8 @@ func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.Se
 				cancel()
 			}()
 		}
-		resp, err := request_ABitOfEverythingService_Echo_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		resp, md, err := request_ABitOfEverythingService_Echo_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, &md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -594,7 +659,8 @@ func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.Se
 				cancel()
 			}()
 		}
-		resp, err := request_ABitOfEverythingService_Echo_1(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		resp, md, err := request_ABitOfEverythingService_Echo_1(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, &md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -613,7 +679,8 @@ func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.Se
 				cancel()
 			}()
 		}
-		resp, err := request_ABitOfEverythingService_Echo_2(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		resp, md, err := request_ABitOfEverythingService_Echo_2(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, &md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -632,7 +699,8 @@ func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.Se
 				cancel()
 			}()
 		}
-		resp, err := request_ABitOfEverythingService_BulkEcho_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		resp, md, err := request_ABitOfEverythingService_BulkEcho_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, &md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return

--- a/examples/examplepb/echo_service.pb.gw.go
+++ b/examples/examplepb/echo_service.pb.gw.go
@@ -109,7 +109,7 @@ func RegisterEchoServiceHandler(ctx context.Context, mux *runtime.ServeMux, conn
 			}()
 		}
 		resp, md, err := request_EchoService_Echo_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
-		ctx = runtime.NewServerMetadataContext(ctx, &md)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -129,7 +129,7 @@ func RegisterEchoServiceHandler(ctx context.Context, mux *runtime.ServeMux, conn
 			}()
 		}
 		resp, md, err := request_EchoService_EchoBody_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
-		ctx = runtime.NewServerMetadataContext(ctx, &md)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return

--- a/examples/examplepb/echo_service.pb.gw.go
+++ b/examples/examplepb/echo_service.pb.gw.go
@@ -29,8 +29,9 @@ var _ = runtime.String
 var _ = json.Marshal
 var _ = utilities.NewDoubleArray
 
-func request_EchoService_Echo_0(ctx context.Context, client EchoServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, error) {
+func request_EchoService_Echo_0(ctx context.Context, client EchoServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq SimpleMessage
+	var metadata runtime.ServerMetadata
 
 	var (
 		val string
@@ -41,26 +42,31 @@ func request_EchoService_Echo_0(ctx context.Context, client EchoServiceClient, r
 
 	val, ok = pathParams["id"]
 	if !ok {
-		return nil, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "id")
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "id")
 	}
 
 	protoReq.Id, err = runtime.String(val)
 
 	if err != nil {
-		return nil, err
+		return nil, metadata, err
 	}
 
-	return client.Echo(ctx, &protoReq)
+	msg, err := client.Echo(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
 }
 
-func request_EchoService_EchoBody_0(ctx context.Context, client EchoServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, error) {
+func request_EchoService_EchoBody_0(ctx context.Context, client EchoServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq SimpleMessage
+	var metadata runtime.ServerMetadata
 
 	if err := json.NewDecoder(req.Body).Decode(&protoReq); err != nil {
-		return nil, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
-	return client.EchoBody(ctx, &protoReq)
+	msg, err := client.EchoBody(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
 }
 
 // RegisterEchoServiceHandlerFromEndpoint is same as RegisterEchoServiceHandler but
@@ -102,7 +108,8 @@ func RegisterEchoServiceHandler(ctx context.Context, mux *runtime.ServeMux, conn
 				cancel()
 			}()
 		}
-		resp, err := request_EchoService_Echo_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		resp, md, err := request_EchoService_Echo_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, &md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -121,7 +128,8 @@ func RegisterEchoServiceHandler(ctx context.Context, mux *runtime.ServeMux, conn
 				cancel()
 			}()
 		}
-		resp, err := request_EchoService_EchoBody_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		resp, md, err := request_EchoService_EchoBody_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, &md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return

--- a/examples/examplepb/flow_combination.pb.gw.go
+++ b/examples/examplepb/flow_combination.pb.gw.go
@@ -29,23 +29,38 @@ var _ = runtime.String
 var _ = json.Marshal
 var _ = utilities.NewDoubleArray
 
-func request_FlowCombination_RpcEmptyRpc_0(ctx context.Context, client FlowCombinationClient, req *http.Request, pathParams map[string]string) (proto.Message, error) {
+func request_FlowCombination_RpcEmptyRpc_0(ctx context.Context, client FlowCombinationClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq EmptyProto
+	var metadata runtime.ServerMetadata
 
-	return client.RpcEmptyRpc(ctx, &protoReq)
+	msg, err := client.RpcEmptyRpc(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
 }
 
-func request_FlowCombination_RpcEmptyStream_0(ctx context.Context, client FlowCombinationClient, req *http.Request, pathParams map[string]string) (FlowCombination_RpcEmptyStreamClient, error) {
+func request_FlowCombination_RpcEmptyStream_0(ctx context.Context, client FlowCombinationClient, req *http.Request, pathParams map[string]string) (FlowCombination_RpcEmptyStreamClient, runtime.ServerMetadata, error) {
 	var protoReq EmptyProto
+	var metadata runtime.ServerMetadata
 
-	return client.RpcEmptyStream(ctx, &protoReq)
+	stream, err := client.RpcEmptyStream(ctx, &protoReq)
+	if err != nil {
+		return nil, metadata, err
+	}
+	header, err := stream.Header()
+	if err != nil {
+		return nil, metadata, err
+	}
+	metadata.HeaderMD = header
+	return stream, metadata, nil
+
 }
 
-func request_FlowCombination_StreamEmptyRpc_0(ctx context.Context, client FlowCombinationClient, req *http.Request, pathParams map[string]string) (proto.Message, error) {
+func request_FlowCombination_StreamEmptyRpc_0(ctx context.Context, client FlowCombinationClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var metadata runtime.ServerMetadata
 	stream, err := client.StreamEmptyRpc(ctx)
 	if err != nil {
 		glog.Errorf("Failed to start streaming: %v", err)
-		return nil, err
+		return nil, metadata, err
 	}
 	dec := json.NewDecoder(req.Body)
 	for {
@@ -56,23 +71,37 @@ func request_FlowCombination_StreamEmptyRpc_0(ctx context.Context, client FlowCo
 		}
 		if err != nil {
 			glog.Errorf("Failed to decode request: %v", err)
-			return nil, grpc.Errorf(codes.InvalidArgument, "%v", err)
+			return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
 		}
 		if err = stream.Send(&protoReq); err != nil {
 			glog.Errorf("Failed to send request: %v", err)
-			return nil, err
+			return nil, metadata, err
 		}
 	}
 
-	return stream.CloseAndRecv()
+	if err := stream.CloseSend(); err != nil {
+		glog.Errorf("Failed to terminate client stream: %v", err)
+		return nil, metadata, err
+	}
+	header, err := stream.Header()
+	if err != nil {
+		glog.Errorf("Failed to get header from client: %v", err)
+		return nil, metadata, err
+	}
+	metadata.HeaderMD = header
+
+	msg, err := stream.CloseAndRecv()
+	metadata.TrailerMD = stream.Trailer()
+	return msg, metadata, err
 
 }
 
-func request_FlowCombination_StreamEmptyStream_0(ctx context.Context, client FlowCombinationClient, req *http.Request, pathParams map[string]string) (FlowCombination_StreamEmptyStreamClient, error) {
+func request_FlowCombination_StreamEmptyStream_0(ctx context.Context, client FlowCombinationClient, req *http.Request, pathParams map[string]string) (FlowCombination_StreamEmptyStreamClient, runtime.ServerMetadata, error) {
+	var metadata runtime.ServerMetadata
 	stream, err := client.StreamEmptyStream(ctx)
 	if err != nil {
 		glog.Errorf("Failed to start streaming: %v", err)
-		return nil, err
+		return nil, metadata, err
 	}
 	dec := json.NewDecoder(req.Body)
 	for {
@@ -83,34 +112,45 @@ func request_FlowCombination_StreamEmptyStream_0(ctx context.Context, client Flo
 		}
 		if err != nil {
 			glog.Errorf("Failed to decode request: %v", err)
-			return nil, grpc.Errorf(codes.InvalidArgument, "%v", err)
+			return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
 		}
 		if err = stream.Send(&protoReq); err != nil {
 			glog.Errorf("Failed to send request: %v", err)
-			return nil, err
+			return nil, metadata, err
 		}
 	}
 
-	if err = stream.CloseSend(); err != nil {
+	if err := stream.CloseSend(); err != nil {
 		glog.Errorf("Failed to terminate client stream: %v", err)
-		return nil, err
+		return nil, metadata, err
 	}
-	return stream, nil
+	header, err := stream.Header()
+	if err != nil {
+		glog.Errorf("Failed to get header from client: %v", err)
+		return nil, metadata, err
+	}
+	metadata.HeaderMD = header
+
+	return stream, metadata, nil
 
 }
 
-func request_FlowCombination_RpcBodyRpc_0(ctx context.Context, client FlowCombinationClient, req *http.Request, pathParams map[string]string) (proto.Message, error) {
+func request_FlowCombination_RpcBodyRpc_0(ctx context.Context, client FlowCombinationClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq NonEmptyProto
+	var metadata runtime.ServerMetadata
 
 	if err := json.NewDecoder(req.Body).Decode(&protoReq); err != nil {
-		return nil, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
-	return client.RpcBodyRpc(ctx, &protoReq)
+	msg, err := client.RpcBodyRpc(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
 }
 
-func request_FlowCombination_RpcBodyRpc_1(ctx context.Context, client FlowCombinationClient, req *http.Request, pathParams map[string]string) (proto.Message, error) {
+func request_FlowCombination_RpcBodyRpc_1(ctx context.Context, client FlowCombinationClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq NonEmptyProto
+	var metadata runtime.ServerMetadata
 
 	var (
 		val string
@@ -121,59 +161,65 @@ func request_FlowCombination_RpcBodyRpc_1(ctx context.Context, client FlowCombin
 
 	val, ok = pathParams["a"]
 	if !ok {
-		return nil, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "a")
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "a")
 	}
 
 	protoReq.A, err = runtime.String(val)
 
 	if err != nil {
-		return nil, err
+		return nil, metadata, err
 	}
 
 	val, ok = pathParams["b"]
 	if !ok {
-		return nil, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "b")
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "b")
 	}
 
 	protoReq.B, err = runtime.String(val)
 
 	if err != nil {
-		return nil, err
+		return nil, metadata, err
 	}
 
 	val, ok = pathParams["c"]
 	if !ok {
-		return nil, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "c")
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "c")
 	}
 
 	protoReq.C, err = runtime.String(val)
 
 	if err != nil {
-		return nil, err
+		return nil, metadata, err
 	}
 
-	return client.RpcBodyRpc(ctx, &protoReq)
+	msg, err := client.RpcBodyRpc(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
 }
 
 var (
 	filter_FlowCombination_RpcBodyRpc_2 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
 )
 
-func request_FlowCombination_RpcBodyRpc_2(ctx context.Context, client FlowCombinationClient, req *http.Request, pathParams map[string]string) (proto.Message, error) {
+func request_FlowCombination_RpcBodyRpc_2(ctx context.Context, client FlowCombinationClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq NonEmptyProto
+	var metadata runtime.ServerMetadata
 
 	if err := runtime.PopulateQueryParameters(&protoReq, req.URL.Query(), filter_FlowCombination_RpcBodyRpc_2); err != nil {
-		return nil, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
-	return client.RpcBodyRpc(ctx, &protoReq)
+	msg, err := client.RpcBodyRpc(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
 }
 
-func request_FlowCombination_RpcBodyRpc_3(ctx context.Context, client FlowCombinationClient, req *http.Request, pathParams map[string]string) (proto.Message, error) {
+func request_FlowCombination_RpcBodyRpc_3(ctx context.Context, client FlowCombinationClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq NonEmptyProto
+	var metadata runtime.ServerMetadata
 
 	if err := json.NewDecoder(req.Body).Decode(&protoReq.C); err != nil {
-		return nil, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	var (
@@ -185,56 +231,62 @@ func request_FlowCombination_RpcBodyRpc_3(ctx context.Context, client FlowCombin
 
 	val, ok = pathParams["a"]
 	if !ok {
-		return nil, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "a")
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "a")
 	}
 
 	protoReq.A, err = runtime.String(val)
 
 	if err != nil {
-		return nil, err
+		return nil, metadata, err
 	}
 
 	val, ok = pathParams["b"]
 	if !ok {
-		return nil, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "b")
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "b")
 	}
 
 	protoReq.B, err = runtime.String(val)
 
 	if err != nil {
-		return nil, err
+		return nil, metadata, err
 	}
 
-	return client.RpcBodyRpc(ctx, &protoReq)
+	msg, err := client.RpcBodyRpc(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
 }
 
 var (
 	filter_FlowCombination_RpcBodyRpc_4 = &utilities.DoubleArray{Encoding: map[string]int{"c": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}
 )
 
-func request_FlowCombination_RpcBodyRpc_4(ctx context.Context, client FlowCombinationClient, req *http.Request, pathParams map[string]string) (proto.Message, error) {
+func request_FlowCombination_RpcBodyRpc_4(ctx context.Context, client FlowCombinationClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq NonEmptyProto
+	var metadata runtime.ServerMetadata
 
 	if err := json.NewDecoder(req.Body).Decode(&protoReq.C); err != nil {
-		return nil, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	if err := runtime.PopulateQueryParameters(&protoReq, req.URL.Query(), filter_FlowCombination_RpcBodyRpc_4); err != nil {
-		return nil, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
-	return client.RpcBodyRpc(ctx, &protoReq)
+	msg, err := client.RpcBodyRpc(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
 }
 
 var (
 	filter_FlowCombination_RpcBodyRpc_5 = &utilities.DoubleArray{Encoding: map[string]int{"c": 0, "a": 1}, Base: []int{1, 1, 2, 0, 0}, Check: []int{0, 1, 1, 2, 3}}
 )
 
-func request_FlowCombination_RpcBodyRpc_5(ctx context.Context, client FlowCombinationClient, req *http.Request, pathParams map[string]string) (proto.Message, error) {
+func request_FlowCombination_RpcBodyRpc_5(ctx context.Context, client FlowCombinationClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq NonEmptyProto
+	var metadata runtime.ServerMetadata
 
 	if err := json.NewDecoder(req.Body).Decode(&protoReq.C); err != nil {
-		return nil, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	var (
@@ -246,28 +298,31 @@ func request_FlowCombination_RpcBodyRpc_5(ctx context.Context, client FlowCombin
 
 	val, ok = pathParams["a"]
 	if !ok {
-		return nil, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "a")
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "a")
 	}
 
 	protoReq.A, err = runtime.String(val)
 
 	if err != nil {
-		return nil, err
+		return nil, metadata, err
 	}
 
 	if err := runtime.PopulateQueryParameters(&protoReq, req.URL.Query(), filter_FlowCombination_RpcBodyRpc_5); err != nil {
-		return nil, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
-	return client.RpcBodyRpc(ctx, &protoReq)
+	msg, err := client.RpcBodyRpc(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
 }
 
 var (
 	filter_FlowCombination_RpcBodyRpc_6 = &utilities.DoubleArray{Encoding: map[string]int{"a": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}
 )
 
-func request_FlowCombination_RpcBodyRpc_6(ctx context.Context, client FlowCombinationClient, req *http.Request, pathParams map[string]string) (proto.Message, error) {
+func request_FlowCombination_RpcBodyRpc_6(ctx context.Context, client FlowCombinationClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq NonEmptyProto
+	var metadata runtime.ServerMetadata
 
 	var (
 		val string
@@ -278,28 +333,31 @@ func request_FlowCombination_RpcBodyRpc_6(ctx context.Context, client FlowCombin
 
 	val, ok = pathParams["a"]
 	if !ok {
-		return nil, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "a")
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "a")
 	}
 
 	protoReq.A, err = runtime.String(val)
 
 	if err != nil {
-		return nil, err
+		return nil, metadata, err
 	}
 
 	if err := runtime.PopulateQueryParameters(&protoReq, req.URL.Query(), filter_FlowCombination_RpcBodyRpc_6); err != nil {
-		return nil, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
-	return client.RpcBodyRpc(ctx, &protoReq)
+	msg, err := client.RpcBodyRpc(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
 }
 
 var (
 	filter_FlowCombination_RpcPathSingleNestedRpc_0 = &utilities.DoubleArray{Encoding: map[string]int{"a": 0, "str": 1}, Base: []int{1, 1, 1, 0}, Check: []int{0, 1, 2, 3}}
 )
 
-func request_FlowCombination_RpcPathSingleNestedRpc_0(ctx context.Context, client FlowCombinationClient, req *http.Request, pathParams map[string]string) (proto.Message, error) {
+func request_FlowCombination_RpcPathSingleNestedRpc_0(ctx context.Context, client FlowCombinationClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq SingleNestedProto
+	var metadata runtime.ServerMetadata
 
 	var (
 		val string
@@ -310,31 +368,34 @@ func request_FlowCombination_RpcPathSingleNestedRpc_0(ctx context.Context, clien
 
 	val, ok = pathParams["a.str"]
 	if !ok {
-		return nil, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "a.str")
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "a.str")
 	}
 
 	err = runtime.PopulateFieldFromPath(&protoReq, "a.str", val)
 
 	if err != nil {
-		return nil, err
+		return nil, metadata, err
 	}
 
 	if err := runtime.PopulateQueryParameters(&protoReq, req.URL.Query(), filter_FlowCombination_RpcPathSingleNestedRpc_0); err != nil {
-		return nil, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
-	return client.RpcPathSingleNestedRpc(ctx, &protoReq)
+	msg, err := client.RpcPathSingleNestedRpc(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
 }
 
 var (
 	filter_FlowCombination_RpcPathNestedRpc_0 = &utilities.DoubleArray{Encoding: map[string]int{"c": 0, "a": 1, "str": 2, "b": 3}, Base: []int{1, 1, 1, 2, 3, 0, 0, 0}, Check: []int{0, 1, 1, 3, 1, 2, 4, 5}}
 )
 
-func request_FlowCombination_RpcPathNestedRpc_0(ctx context.Context, client FlowCombinationClient, req *http.Request, pathParams map[string]string) (proto.Message, error) {
+func request_FlowCombination_RpcPathNestedRpc_0(ctx context.Context, client FlowCombinationClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq NestedProto
+	var metadata runtime.ServerMetadata
 
 	if err := json.NewDecoder(req.Body).Decode(&protoReq.C); err != nil {
-		return nil, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	var (
@@ -346,39 +407,42 @@ func request_FlowCombination_RpcPathNestedRpc_0(ctx context.Context, client Flow
 
 	val, ok = pathParams["a.str"]
 	if !ok {
-		return nil, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "a.str")
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "a.str")
 	}
 
 	err = runtime.PopulateFieldFromPath(&protoReq, "a.str", val)
 
 	if err != nil {
-		return nil, err
+		return nil, metadata, err
 	}
 
 	val, ok = pathParams["b"]
 	if !ok {
-		return nil, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "b")
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "b")
 	}
 
 	protoReq.B, err = runtime.String(val)
 
 	if err != nil {
-		return nil, err
+		return nil, metadata, err
 	}
 
 	if err := runtime.PopulateQueryParameters(&protoReq, req.URL.Query(), filter_FlowCombination_RpcPathNestedRpc_0); err != nil {
-		return nil, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
-	return client.RpcPathNestedRpc(ctx, &protoReq)
+	msg, err := client.RpcPathNestedRpc(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
 }
 
 var (
 	filter_FlowCombination_RpcPathNestedRpc_1 = &utilities.DoubleArray{Encoding: map[string]int{"a": 0, "str": 1}, Base: []int{1, 1, 1, 0}, Check: []int{0, 1, 2, 3}}
 )
 
-func request_FlowCombination_RpcPathNestedRpc_1(ctx context.Context, client FlowCombinationClient, req *http.Request, pathParams map[string]string) (proto.Message, error) {
+func request_FlowCombination_RpcPathNestedRpc_1(ctx context.Context, client FlowCombinationClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq NestedProto
+	var metadata runtime.ServerMetadata
 
 	var (
 		val string
@@ -389,31 +453,34 @@ func request_FlowCombination_RpcPathNestedRpc_1(ctx context.Context, client Flow
 
 	val, ok = pathParams["a.str"]
 	if !ok {
-		return nil, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "a.str")
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "a.str")
 	}
 
 	err = runtime.PopulateFieldFromPath(&protoReq, "a.str", val)
 
 	if err != nil {
-		return nil, err
+		return nil, metadata, err
 	}
 
 	if err := runtime.PopulateQueryParameters(&protoReq, req.URL.Query(), filter_FlowCombination_RpcPathNestedRpc_1); err != nil {
-		return nil, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
-	return client.RpcPathNestedRpc(ctx, &protoReq)
+	msg, err := client.RpcPathNestedRpc(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
 }
 
 var (
 	filter_FlowCombination_RpcPathNestedRpc_2 = &utilities.DoubleArray{Encoding: map[string]int{"c": 0, "a": 1, "str": 2}, Base: []int{1, 1, 1, 2, 0, 0}, Check: []int{0, 1, 1, 3, 2, 4}}
 )
 
-func request_FlowCombination_RpcPathNestedRpc_2(ctx context.Context, client FlowCombinationClient, req *http.Request, pathParams map[string]string) (proto.Message, error) {
+func request_FlowCombination_RpcPathNestedRpc_2(ctx context.Context, client FlowCombinationClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq NestedProto
+	var metadata runtime.ServerMetadata
 
 	if err := json.NewDecoder(req.Body).Decode(&protoReq.C); err != nil {
-		return nil, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	var (
@@ -425,34 +492,48 @@ func request_FlowCombination_RpcPathNestedRpc_2(ctx context.Context, client Flow
 
 	val, ok = pathParams["a.str"]
 	if !ok {
-		return nil, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "a.str")
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "a.str")
 	}
 
 	err = runtime.PopulateFieldFromPath(&protoReq, "a.str", val)
 
 	if err != nil {
-		return nil, err
+		return nil, metadata, err
 	}
 
 	if err := runtime.PopulateQueryParameters(&protoReq, req.URL.Query(), filter_FlowCombination_RpcPathNestedRpc_2); err != nil {
-		return nil, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
-	return client.RpcPathNestedRpc(ctx, &protoReq)
+	msg, err := client.RpcPathNestedRpc(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
 }
 
-func request_FlowCombination_RpcBodyStream_0(ctx context.Context, client FlowCombinationClient, req *http.Request, pathParams map[string]string) (FlowCombination_RpcBodyStreamClient, error) {
+func request_FlowCombination_RpcBodyStream_0(ctx context.Context, client FlowCombinationClient, req *http.Request, pathParams map[string]string) (FlowCombination_RpcBodyStreamClient, runtime.ServerMetadata, error) {
 	var protoReq NonEmptyProto
+	var metadata runtime.ServerMetadata
 
 	if err := json.NewDecoder(req.Body).Decode(&protoReq); err != nil {
-		return nil, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
-	return client.RpcBodyStream(ctx, &protoReq)
+	stream, err := client.RpcBodyStream(ctx, &protoReq)
+	if err != nil {
+		return nil, metadata, err
+	}
+	header, err := stream.Header()
+	if err != nil {
+		return nil, metadata, err
+	}
+	metadata.HeaderMD = header
+	return stream, metadata, nil
+
 }
 
-func request_FlowCombination_RpcBodyStream_1(ctx context.Context, client FlowCombinationClient, req *http.Request, pathParams map[string]string) (FlowCombination_RpcBodyStreamClient, error) {
+func request_FlowCombination_RpcBodyStream_1(ctx context.Context, client FlowCombinationClient, req *http.Request, pathParams map[string]string) (FlowCombination_RpcBodyStreamClient, runtime.ServerMetadata, error) {
 	var protoReq NonEmptyProto
+	var metadata runtime.ServerMetadata
 
 	var (
 		val string
@@ -463,59 +544,81 @@ func request_FlowCombination_RpcBodyStream_1(ctx context.Context, client FlowCom
 
 	val, ok = pathParams["a"]
 	if !ok {
-		return nil, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "a")
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "a")
 	}
 
 	protoReq.A, err = runtime.String(val)
 
 	if err != nil {
-		return nil, err
+		return nil, metadata, err
 	}
 
 	val, ok = pathParams["b"]
 	if !ok {
-		return nil, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "b")
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "b")
 	}
 
 	protoReq.B, err = runtime.String(val)
 
 	if err != nil {
-		return nil, err
+		return nil, metadata, err
 	}
 
 	val, ok = pathParams["c"]
 	if !ok {
-		return nil, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "c")
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "c")
 	}
 
 	protoReq.C, err = runtime.String(val)
 
 	if err != nil {
-		return nil, err
+		return nil, metadata, err
 	}
 
-	return client.RpcBodyStream(ctx, &protoReq)
+	stream, err := client.RpcBodyStream(ctx, &protoReq)
+	if err != nil {
+		return nil, metadata, err
+	}
+	header, err := stream.Header()
+	if err != nil {
+		return nil, metadata, err
+	}
+	metadata.HeaderMD = header
+	return stream, metadata, nil
+
 }
 
 var (
 	filter_FlowCombination_RpcBodyStream_2 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
 )
 
-func request_FlowCombination_RpcBodyStream_2(ctx context.Context, client FlowCombinationClient, req *http.Request, pathParams map[string]string) (FlowCombination_RpcBodyStreamClient, error) {
+func request_FlowCombination_RpcBodyStream_2(ctx context.Context, client FlowCombinationClient, req *http.Request, pathParams map[string]string) (FlowCombination_RpcBodyStreamClient, runtime.ServerMetadata, error) {
 	var protoReq NonEmptyProto
+	var metadata runtime.ServerMetadata
 
 	if err := runtime.PopulateQueryParameters(&protoReq, req.URL.Query(), filter_FlowCombination_RpcBodyStream_2); err != nil {
-		return nil, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
-	return client.RpcBodyStream(ctx, &protoReq)
+	stream, err := client.RpcBodyStream(ctx, &protoReq)
+	if err != nil {
+		return nil, metadata, err
+	}
+	header, err := stream.Header()
+	if err != nil {
+		return nil, metadata, err
+	}
+	metadata.HeaderMD = header
+	return stream, metadata, nil
+
 }
 
-func request_FlowCombination_RpcBodyStream_3(ctx context.Context, client FlowCombinationClient, req *http.Request, pathParams map[string]string) (FlowCombination_RpcBodyStreamClient, error) {
+func request_FlowCombination_RpcBodyStream_3(ctx context.Context, client FlowCombinationClient, req *http.Request, pathParams map[string]string) (FlowCombination_RpcBodyStreamClient, runtime.ServerMetadata, error) {
 	var protoReq NonEmptyProto
+	var metadata runtime.ServerMetadata
 
 	if err := json.NewDecoder(req.Body).Decode(&protoReq.C); err != nil {
-		return nil, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	var (
@@ -527,56 +630,78 @@ func request_FlowCombination_RpcBodyStream_3(ctx context.Context, client FlowCom
 
 	val, ok = pathParams["a"]
 	if !ok {
-		return nil, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "a")
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "a")
 	}
 
 	protoReq.A, err = runtime.String(val)
 
 	if err != nil {
-		return nil, err
+		return nil, metadata, err
 	}
 
 	val, ok = pathParams["b"]
 	if !ok {
-		return nil, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "b")
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "b")
 	}
 
 	protoReq.B, err = runtime.String(val)
 
 	if err != nil {
-		return nil, err
+		return nil, metadata, err
 	}
 
-	return client.RpcBodyStream(ctx, &protoReq)
+	stream, err := client.RpcBodyStream(ctx, &protoReq)
+	if err != nil {
+		return nil, metadata, err
+	}
+	header, err := stream.Header()
+	if err != nil {
+		return nil, metadata, err
+	}
+	metadata.HeaderMD = header
+	return stream, metadata, nil
+
 }
 
 var (
 	filter_FlowCombination_RpcBodyStream_4 = &utilities.DoubleArray{Encoding: map[string]int{"c": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}
 )
 
-func request_FlowCombination_RpcBodyStream_4(ctx context.Context, client FlowCombinationClient, req *http.Request, pathParams map[string]string) (FlowCombination_RpcBodyStreamClient, error) {
+func request_FlowCombination_RpcBodyStream_4(ctx context.Context, client FlowCombinationClient, req *http.Request, pathParams map[string]string) (FlowCombination_RpcBodyStreamClient, runtime.ServerMetadata, error) {
 	var protoReq NonEmptyProto
+	var metadata runtime.ServerMetadata
 
 	if err := json.NewDecoder(req.Body).Decode(&protoReq.C); err != nil {
-		return nil, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	if err := runtime.PopulateQueryParameters(&protoReq, req.URL.Query(), filter_FlowCombination_RpcBodyStream_4); err != nil {
-		return nil, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
-	return client.RpcBodyStream(ctx, &protoReq)
+	stream, err := client.RpcBodyStream(ctx, &protoReq)
+	if err != nil {
+		return nil, metadata, err
+	}
+	header, err := stream.Header()
+	if err != nil {
+		return nil, metadata, err
+	}
+	metadata.HeaderMD = header
+	return stream, metadata, nil
+
 }
 
 var (
 	filter_FlowCombination_RpcBodyStream_5 = &utilities.DoubleArray{Encoding: map[string]int{"c": 0, "a": 1}, Base: []int{1, 1, 2, 0, 0}, Check: []int{0, 1, 1, 2, 3}}
 )
 
-func request_FlowCombination_RpcBodyStream_5(ctx context.Context, client FlowCombinationClient, req *http.Request, pathParams map[string]string) (FlowCombination_RpcBodyStreamClient, error) {
+func request_FlowCombination_RpcBodyStream_5(ctx context.Context, client FlowCombinationClient, req *http.Request, pathParams map[string]string) (FlowCombination_RpcBodyStreamClient, runtime.ServerMetadata, error) {
 	var protoReq NonEmptyProto
+	var metadata runtime.ServerMetadata
 
 	if err := json.NewDecoder(req.Body).Decode(&protoReq.C); err != nil {
-		return nil, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	var (
@@ -588,28 +713,39 @@ func request_FlowCombination_RpcBodyStream_5(ctx context.Context, client FlowCom
 
 	val, ok = pathParams["a"]
 	if !ok {
-		return nil, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "a")
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "a")
 	}
 
 	protoReq.A, err = runtime.String(val)
 
 	if err != nil {
-		return nil, err
+		return nil, metadata, err
 	}
 
 	if err := runtime.PopulateQueryParameters(&protoReq, req.URL.Query(), filter_FlowCombination_RpcBodyStream_5); err != nil {
-		return nil, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
-	return client.RpcBodyStream(ctx, &protoReq)
+	stream, err := client.RpcBodyStream(ctx, &protoReq)
+	if err != nil {
+		return nil, metadata, err
+	}
+	header, err := stream.Header()
+	if err != nil {
+		return nil, metadata, err
+	}
+	metadata.HeaderMD = header
+	return stream, metadata, nil
+
 }
 
 var (
 	filter_FlowCombination_RpcBodyStream_6 = &utilities.DoubleArray{Encoding: map[string]int{"a": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}
 )
 
-func request_FlowCombination_RpcBodyStream_6(ctx context.Context, client FlowCombinationClient, req *http.Request, pathParams map[string]string) (FlowCombination_RpcBodyStreamClient, error) {
+func request_FlowCombination_RpcBodyStream_6(ctx context.Context, client FlowCombinationClient, req *http.Request, pathParams map[string]string) (FlowCombination_RpcBodyStreamClient, runtime.ServerMetadata, error) {
 	var protoReq NonEmptyProto
+	var metadata runtime.ServerMetadata
 
 	var (
 		val string
@@ -620,28 +756,39 @@ func request_FlowCombination_RpcBodyStream_6(ctx context.Context, client FlowCom
 
 	val, ok = pathParams["a"]
 	if !ok {
-		return nil, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "a")
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "a")
 	}
 
 	protoReq.A, err = runtime.String(val)
 
 	if err != nil {
-		return nil, err
+		return nil, metadata, err
 	}
 
 	if err := runtime.PopulateQueryParameters(&protoReq, req.URL.Query(), filter_FlowCombination_RpcBodyStream_6); err != nil {
-		return nil, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
-	return client.RpcBodyStream(ctx, &protoReq)
+	stream, err := client.RpcBodyStream(ctx, &protoReq)
+	if err != nil {
+		return nil, metadata, err
+	}
+	header, err := stream.Header()
+	if err != nil {
+		return nil, metadata, err
+	}
+	metadata.HeaderMD = header
+	return stream, metadata, nil
+
 }
 
 var (
 	filter_FlowCombination_RpcPathSingleNestedStream_0 = &utilities.DoubleArray{Encoding: map[string]int{"a": 0, "str": 1}, Base: []int{1, 1, 1, 0}, Check: []int{0, 1, 2, 3}}
 )
 
-func request_FlowCombination_RpcPathSingleNestedStream_0(ctx context.Context, client FlowCombinationClient, req *http.Request, pathParams map[string]string) (FlowCombination_RpcPathSingleNestedStreamClient, error) {
+func request_FlowCombination_RpcPathSingleNestedStream_0(ctx context.Context, client FlowCombinationClient, req *http.Request, pathParams map[string]string) (FlowCombination_RpcPathSingleNestedStreamClient, runtime.ServerMetadata, error) {
 	var protoReq SingleNestedProto
+	var metadata runtime.ServerMetadata
 
 	var (
 		val string
@@ -652,31 +799,42 @@ func request_FlowCombination_RpcPathSingleNestedStream_0(ctx context.Context, cl
 
 	val, ok = pathParams["a.str"]
 	if !ok {
-		return nil, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "a.str")
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "a.str")
 	}
 
 	err = runtime.PopulateFieldFromPath(&protoReq, "a.str", val)
 
 	if err != nil {
-		return nil, err
+		return nil, metadata, err
 	}
 
 	if err := runtime.PopulateQueryParameters(&protoReq, req.URL.Query(), filter_FlowCombination_RpcPathSingleNestedStream_0); err != nil {
-		return nil, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
-	return client.RpcPathSingleNestedStream(ctx, &protoReq)
+	stream, err := client.RpcPathSingleNestedStream(ctx, &protoReq)
+	if err != nil {
+		return nil, metadata, err
+	}
+	header, err := stream.Header()
+	if err != nil {
+		return nil, metadata, err
+	}
+	metadata.HeaderMD = header
+	return stream, metadata, nil
+
 }
 
 var (
 	filter_FlowCombination_RpcPathNestedStream_0 = &utilities.DoubleArray{Encoding: map[string]int{"c": 0, "a": 1, "str": 2, "b": 3}, Base: []int{1, 1, 1, 2, 3, 0, 0, 0}, Check: []int{0, 1, 1, 3, 1, 2, 4, 5}}
 )
 
-func request_FlowCombination_RpcPathNestedStream_0(ctx context.Context, client FlowCombinationClient, req *http.Request, pathParams map[string]string) (FlowCombination_RpcPathNestedStreamClient, error) {
+func request_FlowCombination_RpcPathNestedStream_0(ctx context.Context, client FlowCombinationClient, req *http.Request, pathParams map[string]string) (FlowCombination_RpcPathNestedStreamClient, runtime.ServerMetadata, error) {
 	var protoReq NestedProto
+	var metadata runtime.ServerMetadata
 
 	if err := json.NewDecoder(req.Body).Decode(&protoReq.C); err != nil {
-		return nil, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	var (
@@ -688,39 +846,50 @@ func request_FlowCombination_RpcPathNestedStream_0(ctx context.Context, client F
 
 	val, ok = pathParams["a.str"]
 	if !ok {
-		return nil, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "a.str")
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "a.str")
 	}
 
 	err = runtime.PopulateFieldFromPath(&protoReq, "a.str", val)
 
 	if err != nil {
-		return nil, err
+		return nil, metadata, err
 	}
 
 	val, ok = pathParams["b"]
 	if !ok {
-		return nil, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "b")
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "b")
 	}
 
 	protoReq.B, err = runtime.String(val)
 
 	if err != nil {
-		return nil, err
+		return nil, metadata, err
 	}
 
 	if err := runtime.PopulateQueryParameters(&protoReq, req.URL.Query(), filter_FlowCombination_RpcPathNestedStream_0); err != nil {
-		return nil, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
-	return client.RpcPathNestedStream(ctx, &protoReq)
+	stream, err := client.RpcPathNestedStream(ctx, &protoReq)
+	if err != nil {
+		return nil, metadata, err
+	}
+	header, err := stream.Header()
+	if err != nil {
+		return nil, metadata, err
+	}
+	metadata.HeaderMD = header
+	return stream, metadata, nil
+
 }
 
 var (
 	filter_FlowCombination_RpcPathNestedStream_1 = &utilities.DoubleArray{Encoding: map[string]int{"a": 0, "str": 1}, Base: []int{1, 1, 1, 0}, Check: []int{0, 1, 2, 3}}
 )
 
-func request_FlowCombination_RpcPathNestedStream_1(ctx context.Context, client FlowCombinationClient, req *http.Request, pathParams map[string]string) (FlowCombination_RpcPathNestedStreamClient, error) {
+func request_FlowCombination_RpcPathNestedStream_1(ctx context.Context, client FlowCombinationClient, req *http.Request, pathParams map[string]string) (FlowCombination_RpcPathNestedStreamClient, runtime.ServerMetadata, error) {
 	var protoReq NestedProto
+	var metadata runtime.ServerMetadata
 
 	var (
 		val string
@@ -731,31 +900,42 @@ func request_FlowCombination_RpcPathNestedStream_1(ctx context.Context, client F
 
 	val, ok = pathParams["a.str"]
 	if !ok {
-		return nil, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "a.str")
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "a.str")
 	}
 
 	err = runtime.PopulateFieldFromPath(&protoReq, "a.str", val)
 
 	if err != nil {
-		return nil, err
+		return nil, metadata, err
 	}
 
 	if err := runtime.PopulateQueryParameters(&protoReq, req.URL.Query(), filter_FlowCombination_RpcPathNestedStream_1); err != nil {
-		return nil, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
-	return client.RpcPathNestedStream(ctx, &protoReq)
+	stream, err := client.RpcPathNestedStream(ctx, &protoReq)
+	if err != nil {
+		return nil, metadata, err
+	}
+	header, err := stream.Header()
+	if err != nil {
+		return nil, metadata, err
+	}
+	metadata.HeaderMD = header
+	return stream, metadata, nil
+
 }
 
 var (
 	filter_FlowCombination_RpcPathNestedStream_2 = &utilities.DoubleArray{Encoding: map[string]int{"c": 0, "a": 1, "str": 2}, Base: []int{1, 1, 1, 2, 0, 0}, Check: []int{0, 1, 1, 3, 2, 4}}
 )
 
-func request_FlowCombination_RpcPathNestedStream_2(ctx context.Context, client FlowCombinationClient, req *http.Request, pathParams map[string]string) (FlowCombination_RpcPathNestedStreamClient, error) {
+func request_FlowCombination_RpcPathNestedStream_2(ctx context.Context, client FlowCombinationClient, req *http.Request, pathParams map[string]string) (FlowCombination_RpcPathNestedStreamClient, runtime.ServerMetadata, error) {
 	var protoReq NestedProto
+	var metadata runtime.ServerMetadata
 
 	if err := json.NewDecoder(req.Body).Decode(&protoReq.C); err != nil {
-		return nil, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
 	var (
@@ -767,20 +947,30 @@ func request_FlowCombination_RpcPathNestedStream_2(ctx context.Context, client F
 
 	val, ok = pathParams["a.str"]
 	if !ok {
-		return nil, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "a.str")
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", "a.str")
 	}
 
 	err = runtime.PopulateFieldFromPath(&protoReq, "a.str", val)
 
 	if err != nil {
-		return nil, err
+		return nil, metadata, err
 	}
 
 	if err := runtime.PopulateQueryParameters(&protoReq, req.URL.Query(), filter_FlowCombination_RpcPathNestedStream_2); err != nil {
-		return nil, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
-	return client.RpcPathNestedStream(ctx, &protoReq)
+	stream, err := client.RpcPathNestedStream(ctx, &protoReq)
+	if err != nil {
+		return nil, metadata, err
+	}
+	header, err := stream.Header()
+	if err != nil {
+		return nil, metadata, err
+	}
+	metadata.HeaderMD = header
+	return stream, metadata, nil
+
 }
 
 // RegisterFlowCombinationHandlerFromEndpoint is same as RegisterFlowCombinationHandler but
@@ -822,7 +1012,8 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 				cancel()
 			}()
 		}
-		resp, err := request_FlowCombination_RpcEmptyRpc_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		resp, md, err := request_FlowCombination_RpcEmptyRpc_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, &md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -841,7 +1032,8 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 				cancel()
 			}()
 		}
-		resp, err := request_FlowCombination_RpcEmptyStream_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		resp, md, err := request_FlowCombination_RpcEmptyStream_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, &md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -860,7 +1052,8 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 				cancel()
 			}()
 		}
-		resp, err := request_FlowCombination_StreamEmptyRpc_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		resp, md, err := request_FlowCombination_StreamEmptyRpc_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, &md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -879,7 +1072,8 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 				cancel()
 			}()
 		}
-		resp, err := request_FlowCombination_StreamEmptyStream_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		resp, md, err := request_FlowCombination_StreamEmptyStream_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, &md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -898,7 +1092,8 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 				cancel()
 			}()
 		}
-		resp, err := request_FlowCombination_RpcBodyRpc_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		resp, md, err := request_FlowCombination_RpcBodyRpc_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, &md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -917,7 +1112,8 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 				cancel()
 			}()
 		}
-		resp, err := request_FlowCombination_RpcBodyRpc_1(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		resp, md, err := request_FlowCombination_RpcBodyRpc_1(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, &md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -936,7 +1132,8 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 				cancel()
 			}()
 		}
-		resp, err := request_FlowCombination_RpcBodyRpc_2(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		resp, md, err := request_FlowCombination_RpcBodyRpc_2(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, &md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -955,7 +1152,8 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 				cancel()
 			}()
 		}
-		resp, err := request_FlowCombination_RpcBodyRpc_3(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		resp, md, err := request_FlowCombination_RpcBodyRpc_3(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, &md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -974,7 +1172,8 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 				cancel()
 			}()
 		}
-		resp, err := request_FlowCombination_RpcBodyRpc_4(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		resp, md, err := request_FlowCombination_RpcBodyRpc_4(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, &md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -993,7 +1192,8 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 				cancel()
 			}()
 		}
-		resp, err := request_FlowCombination_RpcBodyRpc_5(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		resp, md, err := request_FlowCombination_RpcBodyRpc_5(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, &md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -1012,7 +1212,8 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 				cancel()
 			}()
 		}
-		resp, err := request_FlowCombination_RpcBodyRpc_6(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		resp, md, err := request_FlowCombination_RpcBodyRpc_6(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, &md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -1031,7 +1232,8 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 				cancel()
 			}()
 		}
-		resp, err := request_FlowCombination_RpcPathSingleNestedRpc_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		resp, md, err := request_FlowCombination_RpcPathSingleNestedRpc_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, &md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -1050,7 +1252,8 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 				cancel()
 			}()
 		}
-		resp, err := request_FlowCombination_RpcPathNestedRpc_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		resp, md, err := request_FlowCombination_RpcPathNestedRpc_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, &md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -1069,7 +1272,8 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 				cancel()
 			}()
 		}
-		resp, err := request_FlowCombination_RpcPathNestedRpc_1(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		resp, md, err := request_FlowCombination_RpcPathNestedRpc_1(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, &md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -1088,7 +1292,8 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 				cancel()
 			}()
 		}
-		resp, err := request_FlowCombination_RpcPathNestedRpc_2(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		resp, md, err := request_FlowCombination_RpcPathNestedRpc_2(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, &md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -1107,7 +1312,8 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 				cancel()
 			}()
 		}
-		resp, err := request_FlowCombination_RpcBodyStream_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		resp, md, err := request_FlowCombination_RpcBodyStream_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, &md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -1126,7 +1332,8 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 				cancel()
 			}()
 		}
-		resp, err := request_FlowCombination_RpcBodyStream_1(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		resp, md, err := request_FlowCombination_RpcBodyStream_1(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, &md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -1145,7 +1352,8 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 				cancel()
 			}()
 		}
-		resp, err := request_FlowCombination_RpcBodyStream_2(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		resp, md, err := request_FlowCombination_RpcBodyStream_2(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, &md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -1164,7 +1372,8 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 				cancel()
 			}()
 		}
-		resp, err := request_FlowCombination_RpcBodyStream_3(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		resp, md, err := request_FlowCombination_RpcBodyStream_3(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, &md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -1183,7 +1392,8 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 				cancel()
 			}()
 		}
-		resp, err := request_FlowCombination_RpcBodyStream_4(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		resp, md, err := request_FlowCombination_RpcBodyStream_4(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, &md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -1202,7 +1412,8 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 				cancel()
 			}()
 		}
-		resp, err := request_FlowCombination_RpcBodyStream_5(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		resp, md, err := request_FlowCombination_RpcBodyStream_5(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, &md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -1221,7 +1432,8 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 				cancel()
 			}()
 		}
-		resp, err := request_FlowCombination_RpcBodyStream_6(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		resp, md, err := request_FlowCombination_RpcBodyStream_6(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, &md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -1240,7 +1452,8 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 				cancel()
 			}()
 		}
-		resp, err := request_FlowCombination_RpcPathSingleNestedStream_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		resp, md, err := request_FlowCombination_RpcPathSingleNestedStream_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, &md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -1259,7 +1472,8 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 				cancel()
 			}()
 		}
-		resp, err := request_FlowCombination_RpcPathNestedStream_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		resp, md, err := request_FlowCombination_RpcPathNestedStream_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, &md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -1278,7 +1492,8 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 				cancel()
 			}()
 		}
-		resp, err := request_FlowCombination_RpcPathNestedStream_1(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		resp, md, err := request_FlowCombination_RpcPathNestedStream_1(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, &md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -1297,7 +1512,8 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 				cancel()
 			}()
 		}
-		resp, err := request_FlowCombination_RpcPathNestedStream_2(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		resp, md, err := request_FlowCombination_RpcPathNestedStream_2(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, &md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return

--- a/examples/examplepb/flow_combination.pb.gw.go
+++ b/examples/examplepb/flow_combination.pb.gw.go
@@ -1013,7 +1013,7 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 			}()
 		}
 		resp, md, err := request_FlowCombination_RpcEmptyRpc_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
-		ctx = runtime.NewServerMetadataContext(ctx, &md)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -1033,7 +1033,7 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 			}()
 		}
 		resp, md, err := request_FlowCombination_RpcEmptyStream_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
-		ctx = runtime.NewServerMetadataContext(ctx, &md)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -1053,7 +1053,7 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 			}()
 		}
 		resp, md, err := request_FlowCombination_StreamEmptyRpc_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
-		ctx = runtime.NewServerMetadataContext(ctx, &md)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -1073,7 +1073,7 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 			}()
 		}
 		resp, md, err := request_FlowCombination_StreamEmptyStream_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
-		ctx = runtime.NewServerMetadataContext(ctx, &md)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -1093,7 +1093,7 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 			}()
 		}
 		resp, md, err := request_FlowCombination_RpcBodyRpc_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
-		ctx = runtime.NewServerMetadataContext(ctx, &md)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -1113,7 +1113,7 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 			}()
 		}
 		resp, md, err := request_FlowCombination_RpcBodyRpc_1(runtime.AnnotateContext(ctx, req), client, req, pathParams)
-		ctx = runtime.NewServerMetadataContext(ctx, &md)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -1133,7 +1133,7 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 			}()
 		}
 		resp, md, err := request_FlowCombination_RpcBodyRpc_2(runtime.AnnotateContext(ctx, req), client, req, pathParams)
-		ctx = runtime.NewServerMetadataContext(ctx, &md)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -1153,7 +1153,7 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 			}()
 		}
 		resp, md, err := request_FlowCombination_RpcBodyRpc_3(runtime.AnnotateContext(ctx, req), client, req, pathParams)
-		ctx = runtime.NewServerMetadataContext(ctx, &md)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -1173,7 +1173,7 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 			}()
 		}
 		resp, md, err := request_FlowCombination_RpcBodyRpc_4(runtime.AnnotateContext(ctx, req), client, req, pathParams)
-		ctx = runtime.NewServerMetadataContext(ctx, &md)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -1193,7 +1193,7 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 			}()
 		}
 		resp, md, err := request_FlowCombination_RpcBodyRpc_5(runtime.AnnotateContext(ctx, req), client, req, pathParams)
-		ctx = runtime.NewServerMetadataContext(ctx, &md)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -1213,7 +1213,7 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 			}()
 		}
 		resp, md, err := request_FlowCombination_RpcBodyRpc_6(runtime.AnnotateContext(ctx, req), client, req, pathParams)
-		ctx = runtime.NewServerMetadataContext(ctx, &md)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -1233,7 +1233,7 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 			}()
 		}
 		resp, md, err := request_FlowCombination_RpcPathSingleNestedRpc_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
-		ctx = runtime.NewServerMetadataContext(ctx, &md)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -1253,7 +1253,7 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 			}()
 		}
 		resp, md, err := request_FlowCombination_RpcPathNestedRpc_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
-		ctx = runtime.NewServerMetadataContext(ctx, &md)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -1273,7 +1273,7 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 			}()
 		}
 		resp, md, err := request_FlowCombination_RpcPathNestedRpc_1(runtime.AnnotateContext(ctx, req), client, req, pathParams)
-		ctx = runtime.NewServerMetadataContext(ctx, &md)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -1293,7 +1293,7 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 			}()
 		}
 		resp, md, err := request_FlowCombination_RpcPathNestedRpc_2(runtime.AnnotateContext(ctx, req), client, req, pathParams)
-		ctx = runtime.NewServerMetadataContext(ctx, &md)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -1313,7 +1313,7 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 			}()
 		}
 		resp, md, err := request_FlowCombination_RpcBodyStream_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
-		ctx = runtime.NewServerMetadataContext(ctx, &md)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -1333,7 +1333,7 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 			}()
 		}
 		resp, md, err := request_FlowCombination_RpcBodyStream_1(runtime.AnnotateContext(ctx, req), client, req, pathParams)
-		ctx = runtime.NewServerMetadataContext(ctx, &md)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -1353,7 +1353,7 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 			}()
 		}
 		resp, md, err := request_FlowCombination_RpcBodyStream_2(runtime.AnnotateContext(ctx, req), client, req, pathParams)
-		ctx = runtime.NewServerMetadataContext(ctx, &md)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -1373,7 +1373,7 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 			}()
 		}
 		resp, md, err := request_FlowCombination_RpcBodyStream_3(runtime.AnnotateContext(ctx, req), client, req, pathParams)
-		ctx = runtime.NewServerMetadataContext(ctx, &md)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -1393,7 +1393,7 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 			}()
 		}
 		resp, md, err := request_FlowCombination_RpcBodyStream_4(runtime.AnnotateContext(ctx, req), client, req, pathParams)
-		ctx = runtime.NewServerMetadataContext(ctx, &md)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -1413,7 +1413,7 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 			}()
 		}
 		resp, md, err := request_FlowCombination_RpcBodyStream_5(runtime.AnnotateContext(ctx, req), client, req, pathParams)
-		ctx = runtime.NewServerMetadataContext(ctx, &md)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -1433,7 +1433,7 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 			}()
 		}
 		resp, md, err := request_FlowCombination_RpcBodyStream_6(runtime.AnnotateContext(ctx, req), client, req, pathParams)
-		ctx = runtime.NewServerMetadataContext(ctx, &md)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -1453,7 +1453,7 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 			}()
 		}
 		resp, md, err := request_FlowCombination_RpcPathSingleNestedStream_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
-		ctx = runtime.NewServerMetadataContext(ctx, &md)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -1473,7 +1473,7 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 			}()
 		}
 		resp, md, err := request_FlowCombination_RpcPathNestedStream_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
-		ctx = runtime.NewServerMetadataContext(ctx, &md)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -1493,7 +1493,7 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 			}()
 		}
 		resp, md, err := request_FlowCombination_RpcPathNestedStream_1(runtime.AnnotateContext(ctx, req), client, req, pathParams)
-		ctx = runtime.NewServerMetadataContext(ctx, &md)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return
@@ -1513,7 +1513,7 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 			}()
 		}
 		resp, md, err := request_FlowCombination_RpcPathNestedStream_2(runtime.AnnotateContext(ctx, req), client, req, pathParams)
-		ctx = runtime.NewServerMetadataContext(ctx, &md)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return

--- a/examples/integration_test.go
+++ b/examples/integration_test.go
@@ -23,6 +23,11 @@ import (
 	"google.golang.org/grpc/codes"
 )
 
+type errorBody struct {
+	Error string `json:"error"`
+	Code  int    `json:"code"`
+}
+
 func TestIntegration(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
@@ -437,7 +442,7 @@ func testABELookupNotFound(t *testing.T) {
 		return
 	}
 
-	var msg runtime.ErrorBody
+	var msg errorBody
 	if err := json.Unmarshal(buf, &msg); err != nil {
 		t.Errorf("json.Unmarshal(%s, &msg) failed with %v; want success", buf, err)
 		return

--- a/examples/server/a_bit_of_everything.go
+++ b/examples/server/a_bit_of_everything.go
@@ -99,6 +99,17 @@ func (s *_ABitOfEverythingServer) List(_ *examples.EmptyMessage, stream examples
 			return err
 		}
 	}
+
+	// return error when metadata includes error header
+	if header, ok := metadata.FromContext(stream.Context()); ok {
+		if v, ok := header["error"]; ok {
+			stream.SetTrailer(metadata.New(map[string]string{
+				"foo": "foo2",
+				"bar": "bar2",
+			}))
+			return grpc.Errorf(codes.InvalidArgument, "error metadata: %v", v)
+		}
+	}
 	return nil
 }
 

--- a/examples/server/a_bit_of_everything.go
+++ b/examples/server/a_bit_of_everything.go
@@ -83,11 +83,20 @@ func (s *_ABitOfEverythingServer) BulkCreate(stream examples.ABitOfEverythingSer
 func (s *_ABitOfEverythingServer) Lookup(ctx context.Context, msg *examples.IdMessage) (*examples.ABitOfEverything, error) {
 	s.m.Lock()
 	defer s.m.Unlock()
-
 	glog.Info(msg)
+
+	grpc.SendHeader(ctx, metadata.New(map[string]string{
+		"uuid": msg.Uuid,
+	}))
+
 	if a, ok := s.v[msg.Uuid]; ok {
 		return a, nil
 	}
+
+	grpc.SetTrailer(ctx, metadata.New(map[string]string{
+		"foo": "foo2",
+		"bar": "bar2",
+	}))
 	return nil, grpc.Errorf(codes.NotFound, "not found")
 }
 

--- a/examples/server/a_bit_of_everything.go
+++ b/examples/server/a_bit_of_everything.go
@@ -12,6 +12,7 @@ import (
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 )
 
 // Implements of ABitOfEverythingServiceServer
@@ -52,6 +53,7 @@ func (s *_ABitOfEverythingServer) CreateBody(ctx context.Context, msg *examples.
 }
 
 func (s *_ABitOfEverythingServer) BulkCreate(stream examples.ABitOfEverythingService_BulkCreateServer) error {
+
 	ctx := stream.Context()
 	for {
 		msg, err := stream.Recv()
@@ -66,6 +68,15 @@ func (s *_ABitOfEverythingServer) BulkCreate(stream examples.ABitOfEverythingSer
 			return err
 		}
 	}
+
+	stream.SendHeader(metadata.New(map[string]string{
+		"foo": "foo1",
+		"bar": "bar1",
+	}))
+	stream.SetTrailer(metadata.New(map[string]string{
+		"foo": "foo2",
+		"bar": "bar2",
+	}))
 	return stream.SendAndClose(new(examples.EmptyMessage))
 }
 
@@ -137,11 +148,25 @@ func (s *_ABitOfEverythingServer) BulkEcho(stream examples.ABitOfEverythingServi
 		}
 		msgs = append(msgs, msg)
 	}
+
+	hmd := metadata.New(map[string]string{
+		"foo": "foo1",
+		"bar": "bar1",
+	})
+	if err := stream.SendHeader(hmd); err != nil {
+		return err
+	}
+
 	for _, msg := range msgs {
 		glog.Info(msg)
 		if err := stream.Send(msg); err != nil {
 			return err
 		}
 	}
+
+	stream.SetTrailer(metadata.New(map[string]string{
+		"foo": "foo2",
+		"bar": "bar2",
+	}))
 	return nil
 }

--- a/examples/server/echo.go
+++ b/examples/server/echo.go
@@ -4,6 +4,8 @@ import (
 	examples "github.com/gengo/grpc-gateway/examples/examplepb"
 	"github.com/golang/glog"
 	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 )
 
 // Implements of EchoServiceServer
@@ -21,5 +23,13 @@ func (s *echoServer) Echo(ctx context.Context, msg *examples.SimpleMessage) (*ex
 
 func (s *echoServer) EchoBody(ctx context.Context, msg *examples.SimpleMessage) (*examples.SimpleMessage, error) {
 	glog.Info(msg)
+	grpc.SendHeader(ctx, metadata.New(map[string]string{
+		"foo": "foo1",
+		"bar": "bar1",
+	}))
+	grpc.SetTrailer(ctx, metadata.New(map[string]string{
+		"foo": "foo2",
+		"bar": "bar2",
+	}))
 	return msg, nil
 }

--- a/protoc-gen-grpc-gateway/gengateway/template.go
+++ b/protoc-gen-grpc-gateway/gengateway/template.go
@@ -161,7 +161,6 @@ func request_{{.Method.Service.GetName}}_{{.Method.GetName}}_{{.Index}}(ctx cont
 		glog.Errorf("Failed to terminate client stream: %v", err)
 		return nil, metadata, err
 	}
-	metadata.TrailerMD = stream.Trailer()
 	return stream, metadata, nil
 {{else}}
 	msg, err := stream.CloseAndRecv()
@@ -214,7 +213,6 @@ var (
 {{end}}
 {{if .Method.GetServerStreaming}}
 	stream, err := client.{{.Method.GetName}}(ctx, &protoReq)
-	metadata.TrailerMD = stream.Trailer()
 	return stream, metadata, err
 {{else}}
 	msg, err := client.{{.Method.GetName}}(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
@@ -271,7 +269,7 @@ func Register{{$svc.GetName}}Handler(ctx context.Context, mux *runtime.ServeMux,
 			return
 		}
 		{{if $m.GetServerStreaming}}
-		forward_{{$svc.GetName}}_{{$m.GetName}}_{{$b.Index}}(ctx, w, req, func() (proto.Message, error) { return resp.Recv() }, mux.GetForwardResponseOptions()...)
+		forward_{{$svc.GetName}}_{{$m.GetName}}_{{$b.Index}}(ctx, w, req, resp, func() (proto.Message, error) { return resp.Recv() }, mux.GetForwardResponseOptions()...)
 		{{else}}
 		forward_{{$svc.GetName}}_{{$m.GetName}}_{{$b.Index}}(ctx, w, req, resp, mux.GetForwardResponseOptions()...)
 		{{end}}

--- a/protoc-gen-grpc-gateway/gengateway/template.go
+++ b/protoc-gen-grpc-gateway/gengateway/template.go
@@ -127,17 +127,18 @@ var _ = utilities.NewDoubleArray
 
 	_ = template.Must(handlerTemplate.New("request-func-signature").Parse(strings.Replace(`
 {{if .Method.GetServerStreaming}}
-func request_{{.Method.Service.GetName}}_{{.Method.GetName}}_{{.Index}}(ctx context.Context, client {{.Method.Service.GetName}}Client, req *http.Request, pathParams map[string]string) ({{.Method.Service.GetName}}_{{.Method.GetName}}Client, error)
+func request_{{.Method.Service.GetName}}_{{.Method.GetName}}_{{.Index}}(ctx context.Context, client {{.Method.Service.GetName}}Client, req *http.Request, pathParams map[string]string) ({{.Method.Service.GetName}}_{{.Method.GetName}}Client, runtime.ServerMetadata, error)
 {{else}}
-func request_{{.Method.Service.GetName}}_{{.Method.GetName}}_{{.Index}}(ctx context.Context, client {{.Method.Service.GetName}}Client, req *http.Request, pathParams map[string]string) (proto.Message, error)
+func request_{{.Method.Service.GetName}}_{{.Method.GetName}}_{{.Index}}(ctx context.Context, client {{.Method.Service.GetName}}Client, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error)
 {{end}}`, "\n", "", -1)))
 
 	_ = template.Must(handlerTemplate.New("client-streaming-request-func").Parse(`
 {{template "request-func-signature" .}} {
+	var metadata runtime.ServerMetadata
 	stream, err := client.{{.Method.GetName}}(ctx)
 	if err != nil {
 		glog.Errorf("Failed to start streaming: %v", err)
-		return nil, err
+		return nil, metadata, err
 	}
 	dec := json.NewDecoder(req.Body)
 	for {
@@ -148,21 +149,24 @@ func request_{{.Method.Service.GetName}}_{{.Method.GetName}}_{{.Index}}(ctx cont
 		}
 		if err != nil {
 			glog.Errorf("Failed to decode request: %v", err)
-			return nil, grpc.Errorf(codes.InvalidArgument, "%v", err)
+			return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
 		}
 		if err = stream.Send(&protoReq); err != nil {
 			glog.Errorf("Failed to send request: %v", err)
-			return nil, err
+			return nil, metadata, err
 		}
 	}
 {{if .Method.GetServerStreaming}}
 	if err = stream.CloseSend(); err != nil {
 		glog.Errorf("Failed to terminate client stream: %v", err)
-		return nil, err
+		return nil, metadata, err
 	}
-	return stream, nil
+	metadata.TrailerMD = stream.Trailer()
+	return stream, metadata, nil
 {{else}}
-	return stream.CloseAndRecv()
+	msg, err := stream.CloseAndRecv()
+	metadata.TrailerMD = stream.Trailer()
+	return msg, metadata, err
 {{end}}
 }
 `))
@@ -175,9 +179,10 @@ var (
 {{end}}
 {{template "request-func-signature" .}} {
 	var protoReq {{.Method.RequestType.GoType .Method.Service.File.GoPkg.Path}}
+	var metadata runtime.ServerMetadata
 {{if .Body}}
 	if err := json.NewDecoder(req.Body).Decode(&{{.Body.RHS "protoReq"}}); err != nil {
-		return nil, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
 	}
 {{end}}
 {{if .PathParams}}
@@ -190,7 +195,7 @@ var (
 	{{range $param := .PathParams}}
 	val, ok = pathParams[{{$param | printf "%q"}}]
 	if !ok {
-		return nil, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", {{$param | printf "%q"}})
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "missing parameter %s", {{$param | printf "%q"}})
 	}
 {{if $param.IsNestedProto3 }}
 	err = runtime.PopulateFieldFromPath(&protoReq, {{$param | printf "%q"}}, val)
@@ -198,17 +203,23 @@ var (
 	{{$param.RHS "protoReq"}}, err = {{$param.ConvertFuncExpr}}(val)
 {{end}}
 	if err != nil {
-		return nil, err
+		return nil, metadata, err
 	}
 	{{end}}
 {{end}}
 {{if .HasQueryParam}}
 	if err := runtime.PopulateQueryParameters(&protoReq, req.URL.Query(), filter_{{.Method.Service.GetName}}_{{.Method.GetName}}_{{.Index}}); err != nil {
-		return nil, grpc.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
 	}
 {{end}}
-
-	return client.{{.Method.GetName}}(ctx, &protoReq)
+{{if .Method.GetServerStreaming}}
+	stream, err := client.{{.Method.GetName}}(ctx, &protoReq)
+	metadata.TrailerMD = stream.Trailer()
+	return stream, metadata, err
+{{else}}
+	msg, err := client.{{.Method.GetName}}(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+{{end}}
 }`))
 
 	trailerTemplate = template.Must(template.New("trailer").Parse(`
@@ -253,7 +264,8 @@ func Register{{$svc.GetName}}Handler(ctx context.Context, mux *runtime.ServeMux,
 				cancel()
 			}()
 		}
-		resp, err := request_{{$svc.GetName}}_{{$m.GetName}}_{{$b.Index}}(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		resp, md, err := request_{{$svc.GetName}}_{{$m.GetName}}_{{$b.Index}}(runtime.AnnotateContext(ctx, req), client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, &md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return

--- a/protoc-gen-grpc-gateway/gengateway/template.go
+++ b/protoc-gen-grpc-gateway/gengateway/template.go
@@ -278,7 +278,7 @@ func Register{{$svc.GetName}}Handler(ctx context.Context, mux *runtime.ServeMux,
 			}()
 		}
 		resp, md, err := request_{{$svc.GetName}}_{{$m.GetName}}_{{$b.Index}}(runtime.AnnotateContext(ctx, req), client, req, pathParams)
-		ctx = runtime.NewServerMetadataContext(ctx, &md)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
 		if err != nil {
 			runtime.HTTPError(ctx, w, req, err)
 			return

--- a/protoc-gen-grpc-gateway/gengateway/template_test.go
+++ b/protoc-gen-grpc-gateway/gengateway/template_test.go
@@ -133,11 +133,11 @@ func TestApplyTemplateRequestWithoutClientStreaming(t *testing.T) {
 	}{
 		{
 			serverStreaming: false,
-			sigWant:         `func request_ExampleService_Echo_0(ctx context.Context, client ExampleServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, error) {`,
+			sigWant:         `func request_ExampleService_Echo_0(ctx context.Context, client ExampleServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {`,
 		},
 		{
 			serverStreaming: true,
-			sigWant:         `func request_ExampleService_Echo_0(ctx context.Context, client ExampleServiceClient, req *http.Request, pathParams map[string]string) (ExampleService_EchoClient, error) {`,
+			sigWant:         `func request_ExampleService_Echo_0(ctx context.Context, client ExampleServiceClient, req *http.Request, pathParams map[string]string) (ExampleService_EchoClient, runtime.ServerMetadata, error) {`,
 		},
 	} {
 		meth.ServerStreaming = proto.Bool(spec.serverStreaming)
@@ -294,11 +294,11 @@ func TestApplyTemplateRequestWithClientStreaming(t *testing.T) {
 	}{
 		{
 			serverStreaming: false,
-			sigWant:         `func request_ExampleService_Echo_0(ctx context.Context, client ExampleServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, error) {`,
+			sigWant:         `func request_ExampleService_Echo_0(ctx context.Context, client ExampleServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {`,
 		},
 		{
 			serverStreaming: true,
-			sigWant:         `func request_ExampleService_Echo_0(ctx context.Context, client ExampleServiceClient, req *http.Request, pathParams map[string]string) (ExampleService_EchoClient, error) {`,
+			sigWant:         `func request_ExampleService_Echo_0(ctx context.Context, client ExampleServiceClient, req *http.Request, pathParams map[string]string) (ExampleService_EchoClient, runtime.ServerMetadata, error) {`,
 		},
 	} {
 		meth.ServerStreaming = proto.Bool(spec.serverStreaming)

--- a/runtime/context.go
+++ b/runtime/context.go
@@ -35,3 +35,21 @@ func AnnotateContext(ctx context.Context, req *http.Request) context.Context {
 	}
 	return metadata.NewContext(ctx, metadata.Pairs(pairs...))
 }
+
+type ServerMetadata struct {
+	HeaderMD  metadata.MD
+	TrailerMD metadata.MD
+}
+
+type serverMetadataKey struct{}
+
+// NewServerMetadataContext creates a new context with ServerMetadata
+func NewServerMetadataContext(ctx context.Context, md *ServerMetadata) context.Context {
+	return context.WithValue(ctx, serverMetadataKey{}, md)
+}
+
+// ServerMetadataFromContext returns the ServerMetadata in ctx
+func ServerMetadataFromContext(ctx context.Context) (md *ServerMetadata, ok bool) {
+	md, ok = ctx.Value(serverMetadataKey{}).(*ServerMetadata)
+	return
+}

--- a/runtime/context.go
+++ b/runtime/context.go
@@ -9,6 +9,7 @@ import (
 )
 
 const metadataHeaderPrefix = "Grpc-Metadata-"
+const metadataTrailerPrefix = "Grpc-Trailer-"
 
 /*
 AnnotateContext adds context information such as metadata from the request.

--- a/runtime/context.go
+++ b/runtime/context.go
@@ -37,6 +37,7 @@ func AnnotateContext(ctx context.Context, req *http.Request) context.Context {
 	return metadata.NewContext(ctx, metadata.Pairs(pairs...))
 }
 
+// ServerMetadata consists of metadata sent from gRPC server.
 type ServerMetadata struct {
 	HeaderMD  metadata.MD
 	TrailerMD metadata.MD
@@ -45,12 +46,12 @@ type ServerMetadata struct {
 type serverMetadataKey struct{}
 
 // NewServerMetadataContext creates a new context with ServerMetadata
-func NewServerMetadataContext(ctx context.Context, md *ServerMetadata) context.Context {
+func NewServerMetadataContext(ctx context.Context, md ServerMetadata) context.Context {
 	return context.WithValue(ctx, serverMetadataKey{}, md)
 }
 
 // ServerMetadataFromContext returns the ServerMetadata in ctx
-func ServerMetadataFromContext(ctx context.Context) (md *ServerMetadata, ok bool) {
-	md, ok = ctx.Value(serverMetadataKey{}).(*ServerMetadata)
+func ServerMetadataFromContext(ctx context.Context) (md ServerMetadata, ok bool) {
+	md, ok = ctx.Value(serverMetadataKey{}).(ServerMetadata)
 	return
 }

--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -62,10 +62,9 @@ var (
 	OtherErrorHandler = DefaultOtherErrorHandler
 )
 
-type ErrorBody struct {
-	Error   string      `json:"error"`
-	Code    int         `json:"code"`
-	Trailer metadata.MD `json:"trailer,omitempty"`
+type errorBody struct {
+	Error string `json:"error"`
+	Code  int    `json:"code"`
 }
 
 // DefaultHTTPError is the default implementation of HTTPError.
@@ -79,7 +78,7 @@ func DefaultHTTPError(ctx context.Context, w http.ResponseWriter, _ *http.Reques
 
 	w.Header().Del("Trailer")
 	w.Header().Set("Content-Type", "application/json")
-	body := ErrorBody{
+	body := errorBody{
 		Error: grpc.ErrorDesc(err),
 		Code:  int(grpc.Code(err)),
 	}

--- a/runtime/errors.go
+++ b/runtime/errors.go
@@ -9,7 +9,6 @@ import (
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/metadata"
 )
 
 // HTTPStatusFromCode converts a gRPC error code into the corresponding HTTP response status.

--- a/runtime/handler.go
+++ b/runtime/handler.go
@@ -80,6 +80,20 @@ func ForwardResponseStream(ctx context.Context, w http.ResponseWriter, req *http
 
 // ForwardResponseMessage forwards the message "resp" from gRPC server to REST client.
 func ForwardResponseMessage(ctx context.Context, w http.ResponseWriter, req *http.Request, resp proto.Message, opts ...func(context.Context, http.ResponseWriter, proto.Message) error) {
+	md, ok := ServerMetadataFromContext(ctx)
+	if !ok {
+		glog.Errorf("Failed to extract ServerMetadata from context")
+	}
+
+	if md != nil {
+		for k, vs := range md.HeaderMD {
+			hKey := fmt.Sprintf("%s%s", metadataHeaderPrefix, k)
+			for i := range vs {
+				w.Header().Add(hKey, vs[i])
+			}
+		}
+	}
+
 	w.Header().Set("Content-Type", "application/json")
 	if err := handleForwardResponseOptions(ctx, w, resp, opts); err != nil {
 		HTTPError(ctx, w, req, err)

--- a/runtime/handler.go
+++ b/runtime/handler.go
@@ -76,11 +76,7 @@ func ForwardResponseStream(ctx context.Context, w http.ResponseWriter, req *http
 	}
 }
 
-func handleForwardResponseServerMetadata(w http.ResponseWriter, md *ServerMetadata) {
-	if md == nil {
-		return
-	}
-
+func handleForwardResponseServerMetadata(w http.ResponseWriter, md ServerMetadata) {
 	for k, vs := range md.HeaderMD {
 		hKey := fmt.Sprintf("%s%s", metadataHeaderPrefix, k)
 		for i := range vs {
@@ -89,22 +85,14 @@ func handleForwardResponseServerMetadata(w http.ResponseWriter, md *ServerMetada
 	}
 }
 
-func handleForwardResponseTrailerHeader(w http.ResponseWriter, md *ServerMetadata) {
-	if md == nil {
-		return
-	}
-
+func handleForwardResponseTrailerHeader(w http.ResponseWriter, md ServerMetadata) {
 	for k := range md.TrailerMD {
 		tKey := textproto.CanonicalMIMEHeaderKey(fmt.Sprintf("%s%s", metadataTrailerPrefix, k))
 		w.Header().Add("Trailer", tKey)
 	}
 }
 
-func handleForwardResponseTrailer(w http.ResponseWriter, md *ServerMetadata) {
-	if md == nil {
-		return
-	}
-
+func handleForwardResponseTrailer(w http.ResponseWriter, md ServerMetadata) {
 	for k, vs := range md.TrailerMD {
 		tKey := fmt.Sprintf("%s%s", metadataTrailerPrefix, k)
 		for i := range vs {

--- a/runtime/handler.go
+++ b/runtime/handler.go
@@ -10,26 +10,35 @@ import (
 	"github.com/golang/protobuf/proto"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 )
 
 type responseStreamChunk struct {
-	Result proto.Message       `json:"result,omitempty"`
-	Error  *responseStreamError `json:"error,omitempty"`
+	Result proto.Message        `json:"result,omitempty"`
+	Error  *ResponseStreamError `json:"error,omitempty"`
 }
 
-type responseStreamError struct {
-	GrpcCode   int    `json:"grpc_code, omitempty"`
-	HTTPCode   int    `json:"http_code, omitempty"`
-	Message    string `json:"message, omitempty"`
-	HTTPStatus string `json:"http_status, omitempty"`
+type ResponseStreamError struct {
+	GrpcCode   int         `json:"grpc_code, omitempty"`
+	HTTPCode   int         `json:"http_code, omitempty"`
+	Message    string      `json:"message, omitempty"`
+	HTTPStatus string      `json:"http_status, omitempty"`
+	Trailer    metadata.MD `json:"trailer, omitempty"`
 }
 
 // ForwardResponseStream forwards the stream from gRPC server to REST client.
-func ForwardResponseStream(ctx context.Context, w http.ResponseWriter, req *http.Request, recv func() (proto.Message, error), opts ...func(context.Context, http.ResponseWriter, proto.Message) error) {
+func ForwardResponseStream(ctx context.Context, w http.ResponseWriter, req *http.Request, stream grpc.ClientStream, recv func() (proto.Message, error), opts ...func(context.Context, http.ResponseWriter, proto.Message) error) {
 	f, ok := w.(http.Flusher)
 	if !ok {
 		glog.Errorf("Flush not supported in %T", w)
 		http.Error(w, "unexpected type of web server", http.StatusInternalServerError)
+		return
+	}
+
+	md, ok := ServerMetadataFromContext(ctx)
+	if !ok {
+		glog.Errorf("Failed to extract ServerMetadata from context")
+		http.Error(w, "unexpected error", http.StatusInternalServerError)
 		return
 	}
 
@@ -47,11 +56,13 @@ func ForwardResponseStream(ctx context.Context, w http.ResponseWriter, req *http
 			return
 		}
 		if err != nil {
-			handleForwardResponseStreamError(w, err)
+			md.TrailerMD = stream.Trailer()
+			handleForwardResponseStreamError(ctx, w, err)
 			return
 		}
 		if err := handleForwardResponseOptions(ctx, w, resp, opts); err != nil {
-			handleForwardResponseStreamError(w, err)
+			md.TrailerMD = stream.Trailer()
+			handleForwardResponseStreamError(ctx, w, err)
 			return
 		}
 		buf, err := json.Marshal(responseStreamChunk{Result: resp})
@@ -100,13 +111,23 @@ func handleForwardResponseOptions(ctx context.Context, w http.ResponseWriter, re
 	return nil
 }
 
-func handleForwardResponseStreamError(w http.ResponseWriter, err error) {
+func handleForwardResponseStreamError(ctx context.Context, w http.ResponseWriter, err error) {
+	md, ok := ServerMetadataFromContext(ctx)
+	if !ok {
+		glog.Errorf("Failed to extract ServerMetadata from context")
+		return
+	}
+
 	grpcCode := grpc.Code(err)
 	httpCode := HTTPStatusFromCode(grpcCode)
-	resp := responseStreamChunk{Error: &responseStreamError{GrpcCode: int(grpcCode),
-		HTTPCode:   httpCode,
-		Message:    err.Error(),
-		HTTPStatus: http.StatusText(httpCode)}}
+	resp := responseStreamChunk{
+		Error: &ResponseStreamError{
+			GrpcCode:   int(grpcCode),
+			HTTPCode:   httpCode,
+			Message:    err.Error(),
+			HTTPStatus: http.StatusText(httpCode),
+			Trailer:    md.TrailerMD,
+		}}
 	buf, merr := json.Marshal(resp)
 	if merr != nil {
 		glog.Errorf("Failed to marshal an error: %v", merr)


### PR DESCRIPTION
gRPC recommends application-level error information should be returned as Trailer metadata. We have to use  `grpc.CallOption` for each rpc call in order to get the metadata at client side. This PR makes protoc-gen-grpc-gateway generates codes with `grpc.CallOption`. And the metadata are set in context, so handlers can extract the metadata by `runtime.CallInfoFromContext`.

Actually I had a plan to return those metadata as HTTP header or body in JSON especially in `DefaultHTTPError` handler. However metadata possibly includes binary or values must be escaped, so default handler doesn't care metadata by default.
EDIT: So I recommend to define a handler which utilizes metadata and overwrite default handlers.

Any ideas or comments are welcome.