### PR TITLE
Fix the swagger section of the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Make sure that your `$GOPATH/bin` is in your `$PATH`.
    protoc -I/usr/local/include -I. \
      -I$GOPATH/src \
      -I$GOPATH/src/github.com/gengo/grpc-gateway/third_party/googleapis \
-     --grpc-swagger_out=logtostderr=true:. \
+     --swagger_out=logtostderr=true:. \
      path/to/your_service.proto
    ```
 


### PR DESCRIPTION
For me to create a *.swagger.json I had to call it with --swagger_out=...

Alternative: change path from protoc-gen-swagger to protoc-gen-grpc-swagger