### PR TITLE
README: Suggest go get -u by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@ make check
 sudo make install
 ```
 
-Then, `go get` as usual.
+Then, `go get -u` as usual.
 
 ```sh
-go get github.com/gengo/grpc-gateway/protoc-gen-grpc-gateway
-go get github.com/golang/protobuf/protoc-gen-go
+go get -u github.com/gengo/grpc-gateway/protoc-gen-grpc-gateway
+go get -u github.com/golang/protobuf/protoc-gen-go
 ```
  
 ## Usage


### PR DESCRIPTION
Suggesting `go get -u` is a safer default. It results in a more predictable action, the user will end up with the latest version of `grpc-gateway` and all its dependencies. Otherwise, the versions users end up with will be arbitrary, which may lead to issues. If users prefer not to update dependencies, they can always `go get` without `-u` flag.

As an example of the issue this would help resolve, see #103.