### PR TITLE
Fix a goroutine-leak in HTTP keep-alive

### DIFF
--- a/examples/examplepb/a_bit_of_everything.pb.gw.go
+++ b/examples/examplepb/a_bit_of_everything.pb.gw.go
@@ -492,11 +492,15 @@ func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.Se
 
 	mux.Handle("POST", pattern_ABitOfEverythingService_Create_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
 		closeNotifier, ok := w.(http.CloseNotifier)
 		if ok {
 			go func() {
-				<-closeNotifier.CloseNotify()
-				cancel()
+				select {
+				case <-ctx.Done():
+				case <-closeNotifier.CloseNotify():
+					cancel()
+				}
 			}()
 		}
 		resp, md, err := request_ABitOfEverythingService_Create_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
@@ -512,11 +516,15 @@ func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.Se
 
 	mux.Handle("POST", pattern_ABitOfEverythingService_CreateBody_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
 		closeNotifier, ok := w.(http.CloseNotifier)
 		if ok {
 			go func() {
-				<-closeNotifier.CloseNotify()
-				cancel()
+				select {
+				case <-ctx.Done():
+				case <-closeNotifier.CloseNotify():
+					cancel()
+				}
 			}()
 		}
 		resp, md, err := request_ABitOfEverythingService_CreateBody_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
@@ -532,11 +540,15 @@ func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.Se
 
 	mux.Handle("POST", pattern_ABitOfEverythingService_BulkCreate_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
 		closeNotifier, ok := w.(http.CloseNotifier)
 		if ok {
 			go func() {
-				<-closeNotifier.CloseNotify()
-				cancel()
+				select {
+				case <-ctx.Done():
+				case <-closeNotifier.CloseNotify():
+					cancel()
+				}
 			}()
 		}
 		resp, md, err := request_ABitOfEverythingService_BulkCreate_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
@@ -552,11 +564,15 @@ func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.Se
 
 	mux.Handle("GET", pattern_ABitOfEverythingService_Lookup_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
 		closeNotifier, ok := w.(http.CloseNotifier)
 		if ok {
 			go func() {
-				<-closeNotifier.CloseNotify()
-				cancel()
+				select {
+				case <-ctx.Done():
+				case <-closeNotifier.CloseNotify():
+					cancel()
+				}
 			}()
 		}
 		resp, md, err := request_ABitOfEverythingService_Lookup_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
@@ -572,11 +588,15 @@ func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.Se
 
 	mux.Handle("GET", pattern_ABitOfEverythingService_List_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
 		closeNotifier, ok := w.(http.CloseNotifier)
 		if ok {
 			go func() {
-				<-closeNotifier.CloseNotify()
-				cancel()
+				select {
+				case <-ctx.Done():
+				case <-closeNotifier.CloseNotify():
+					cancel()
+				}
 			}()
 		}
 		resp, md, err := request_ABitOfEverythingService_List_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
@@ -592,11 +612,15 @@ func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.Se
 
 	mux.Handle("PUT", pattern_ABitOfEverythingService_Update_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
 		closeNotifier, ok := w.(http.CloseNotifier)
 		if ok {
 			go func() {
-				<-closeNotifier.CloseNotify()
-				cancel()
+				select {
+				case <-ctx.Done():
+				case <-closeNotifier.CloseNotify():
+					cancel()
+				}
 			}()
 		}
 		resp, md, err := request_ABitOfEverythingService_Update_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
@@ -612,11 +636,15 @@ func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.Se
 
 	mux.Handle("DELETE", pattern_ABitOfEverythingService_Delete_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
 		closeNotifier, ok := w.(http.CloseNotifier)
 		if ok {
 			go func() {
-				<-closeNotifier.CloseNotify()
-				cancel()
+				select {
+				case <-ctx.Done():
+				case <-closeNotifier.CloseNotify():
+					cancel()
+				}
 			}()
 		}
 		resp, md, err := request_ABitOfEverythingService_Delete_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
@@ -632,11 +660,15 @@ func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.Se
 
 	mux.Handle("GET", pattern_ABitOfEverythingService_Echo_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
 		closeNotifier, ok := w.(http.CloseNotifier)
 		if ok {
 			go func() {
-				<-closeNotifier.CloseNotify()
-				cancel()
+				select {
+				case <-ctx.Done():
+				case <-closeNotifier.CloseNotify():
+					cancel()
+				}
 			}()
 		}
 		resp, md, err := request_ABitOfEverythingService_Echo_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
@@ -652,11 +684,15 @@ func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.Se
 
 	mux.Handle("POST", pattern_ABitOfEverythingService_Echo_1, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
 		closeNotifier, ok := w.(http.CloseNotifier)
 		if ok {
 			go func() {
-				<-closeNotifier.CloseNotify()
-				cancel()
+				select {
+				case <-ctx.Done():
+				case <-closeNotifier.CloseNotify():
+					cancel()
+				}
 			}()
 		}
 		resp, md, err := request_ABitOfEverythingService_Echo_1(runtime.AnnotateContext(ctx, req), client, req, pathParams)
@@ -672,11 +708,15 @@ func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.Se
 
 	mux.Handle("GET", pattern_ABitOfEverythingService_Echo_2, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
 		closeNotifier, ok := w.(http.CloseNotifier)
 		if ok {
 			go func() {
-				<-closeNotifier.CloseNotify()
-				cancel()
+				select {
+				case <-ctx.Done():
+				case <-closeNotifier.CloseNotify():
+					cancel()
+				}
 			}()
 		}
 		resp, md, err := request_ABitOfEverythingService_Echo_2(runtime.AnnotateContext(ctx, req), client, req, pathParams)
@@ -692,11 +732,15 @@ func RegisterABitOfEverythingServiceHandler(ctx context.Context, mux *runtime.Se
 
 	mux.Handle("POST", pattern_ABitOfEverythingService_BulkEcho_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
 		closeNotifier, ok := w.(http.CloseNotifier)
 		if ok {
 			go func() {
-				<-closeNotifier.CloseNotify()
-				cancel()
+				select {
+				case <-ctx.Done():
+				case <-closeNotifier.CloseNotify():
+					cancel()
+				}
 			}()
 		}
 		resp, md, err := request_ABitOfEverythingService_BulkEcho_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)

--- a/examples/examplepb/echo_service.pb.gw.go
+++ b/examples/examplepb/echo_service.pb.gw.go
@@ -101,11 +101,15 @@ func RegisterEchoServiceHandler(ctx context.Context, mux *runtime.ServeMux, conn
 
 	mux.Handle("POST", pattern_EchoService_Echo_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
 		closeNotifier, ok := w.(http.CloseNotifier)
 		if ok {
 			go func() {
-				<-closeNotifier.CloseNotify()
-				cancel()
+				select {
+				case <-ctx.Done():
+				case <-closeNotifier.CloseNotify():
+					cancel()
+				}
 			}()
 		}
 		resp, md, err := request_EchoService_Echo_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
@@ -121,11 +125,15 @@ func RegisterEchoServiceHandler(ctx context.Context, mux *runtime.ServeMux, conn
 
 	mux.Handle("POST", pattern_EchoService_EchoBody_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
 		closeNotifier, ok := w.(http.CloseNotifier)
 		if ok {
 			go func() {
-				<-closeNotifier.CloseNotify()
-				cancel()
+				select {
+				case <-ctx.Done():
+				case <-closeNotifier.CloseNotify():
+					cancel()
+				}
 			}()
 		}
 		resp, md, err := request_EchoService_EchoBody_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)

--- a/examples/examplepb/flow_combination.pb.gw.go
+++ b/examples/examplepb/flow_combination.pb.gw.go
@@ -1005,11 +1005,15 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 
 	mux.Handle("POST", pattern_FlowCombination_RpcEmptyRpc_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
 		closeNotifier, ok := w.(http.CloseNotifier)
 		if ok {
 			go func() {
-				<-closeNotifier.CloseNotify()
-				cancel()
+				select {
+				case <-ctx.Done():
+				case <-closeNotifier.CloseNotify():
+					cancel()
+				}
 			}()
 		}
 		resp, md, err := request_FlowCombination_RpcEmptyRpc_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
@@ -1025,11 +1029,15 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 
 	mux.Handle("POST", pattern_FlowCombination_RpcEmptyStream_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
 		closeNotifier, ok := w.(http.CloseNotifier)
 		if ok {
 			go func() {
-				<-closeNotifier.CloseNotify()
-				cancel()
+				select {
+				case <-ctx.Done():
+				case <-closeNotifier.CloseNotify():
+					cancel()
+				}
 			}()
 		}
 		resp, md, err := request_FlowCombination_RpcEmptyStream_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
@@ -1045,11 +1053,15 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 
 	mux.Handle("POST", pattern_FlowCombination_StreamEmptyRpc_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
 		closeNotifier, ok := w.(http.CloseNotifier)
 		if ok {
 			go func() {
-				<-closeNotifier.CloseNotify()
-				cancel()
+				select {
+				case <-ctx.Done():
+				case <-closeNotifier.CloseNotify():
+					cancel()
+				}
 			}()
 		}
 		resp, md, err := request_FlowCombination_StreamEmptyRpc_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
@@ -1065,11 +1077,15 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 
 	mux.Handle("POST", pattern_FlowCombination_StreamEmptyStream_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
 		closeNotifier, ok := w.(http.CloseNotifier)
 		if ok {
 			go func() {
-				<-closeNotifier.CloseNotify()
-				cancel()
+				select {
+				case <-ctx.Done():
+				case <-closeNotifier.CloseNotify():
+					cancel()
+				}
 			}()
 		}
 		resp, md, err := request_FlowCombination_StreamEmptyStream_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
@@ -1085,11 +1101,15 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 
 	mux.Handle("POST", pattern_FlowCombination_RpcBodyRpc_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
 		closeNotifier, ok := w.(http.CloseNotifier)
 		if ok {
 			go func() {
-				<-closeNotifier.CloseNotify()
-				cancel()
+				select {
+				case <-ctx.Done():
+				case <-closeNotifier.CloseNotify():
+					cancel()
+				}
 			}()
 		}
 		resp, md, err := request_FlowCombination_RpcBodyRpc_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
@@ -1105,11 +1125,15 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 
 	mux.Handle("POST", pattern_FlowCombination_RpcBodyRpc_1, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
 		closeNotifier, ok := w.(http.CloseNotifier)
 		if ok {
 			go func() {
-				<-closeNotifier.CloseNotify()
-				cancel()
+				select {
+				case <-ctx.Done():
+				case <-closeNotifier.CloseNotify():
+					cancel()
+				}
 			}()
 		}
 		resp, md, err := request_FlowCombination_RpcBodyRpc_1(runtime.AnnotateContext(ctx, req), client, req, pathParams)
@@ -1125,11 +1149,15 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 
 	mux.Handle("POST", pattern_FlowCombination_RpcBodyRpc_2, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
 		closeNotifier, ok := w.(http.CloseNotifier)
 		if ok {
 			go func() {
-				<-closeNotifier.CloseNotify()
-				cancel()
+				select {
+				case <-ctx.Done():
+				case <-closeNotifier.CloseNotify():
+					cancel()
+				}
 			}()
 		}
 		resp, md, err := request_FlowCombination_RpcBodyRpc_2(runtime.AnnotateContext(ctx, req), client, req, pathParams)
@@ -1145,11 +1173,15 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 
 	mux.Handle("POST", pattern_FlowCombination_RpcBodyRpc_3, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
 		closeNotifier, ok := w.(http.CloseNotifier)
 		if ok {
 			go func() {
-				<-closeNotifier.CloseNotify()
-				cancel()
+				select {
+				case <-ctx.Done():
+				case <-closeNotifier.CloseNotify():
+					cancel()
+				}
 			}()
 		}
 		resp, md, err := request_FlowCombination_RpcBodyRpc_3(runtime.AnnotateContext(ctx, req), client, req, pathParams)
@@ -1165,11 +1197,15 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 
 	mux.Handle("POST", pattern_FlowCombination_RpcBodyRpc_4, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
 		closeNotifier, ok := w.(http.CloseNotifier)
 		if ok {
 			go func() {
-				<-closeNotifier.CloseNotify()
-				cancel()
+				select {
+				case <-ctx.Done():
+				case <-closeNotifier.CloseNotify():
+					cancel()
+				}
 			}()
 		}
 		resp, md, err := request_FlowCombination_RpcBodyRpc_4(runtime.AnnotateContext(ctx, req), client, req, pathParams)
@@ -1185,11 +1221,15 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 
 	mux.Handle("POST", pattern_FlowCombination_RpcBodyRpc_5, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
 		closeNotifier, ok := w.(http.CloseNotifier)
 		if ok {
 			go func() {
-				<-closeNotifier.CloseNotify()
-				cancel()
+				select {
+				case <-ctx.Done():
+				case <-closeNotifier.CloseNotify():
+					cancel()
+				}
 			}()
 		}
 		resp, md, err := request_FlowCombination_RpcBodyRpc_5(runtime.AnnotateContext(ctx, req), client, req, pathParams)
@@ -1205,11 +1245,15 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 
 	mux.Handle("POST", pattern_FlowCombination_RpcBodyRpc_6, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
 		closeNotifier, ok := w.(http.CloseNotifier)
 		if ok {
 			go func() {
-				<-closeNotifier.CloseNotify()
-				cancel()
+				select {
+				case <-ctx.Done():
+				case <-closeNotifier.CloseNotify():
+					cancel()
+				}
 			}()
 		}
 		resp, md, err := request_FlowCombination_RpcBodyRpc_6(runtime.AnnotateContext(ctx, req), client, req, pathParams)
@@ -1225,11 +1269,15 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 
 	mux.Handle("POST", pattern_FlowCombination_RpcPathSingleNestedRpc_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
 		closeNotifier, ok := w.(http.CloseNotifier)
 		if ok {
 			go func() {
-				<-closeNotifier.CloseNotify()
-				cancel()
+				select {
+				case <-ctx.Done():
+				case <-closeNotifier.CloseNotify():
+					cancel()
+				}
 			}()
 		}
 		resp, md, err := request_FlowCombination_RpcPathSingleNestedRpc_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
@@ -1245,11 +1293,15 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 
 	mux.Handle("POST", pattern_FlowCombination_RpcPathNestedRpc_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
 		closeNotifier, ok := w.(http.CloseNotifier)
 		if ok {
 			go func() {
-				<-closeNotifier.CloseNotify()
-				cancel()
+				select {
+				case <-ctx.Done():
+				case <-closeNotifier.CloseNotify():
+					cancel()
+				}
 			}()
 		}
 		resp, md, err := request_FlowCombination_RpcPathNestedRpc_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
@@ -1265,11 +1317,15 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 
 	mux.Handle("POST", pattern_FlowCombination_RpcPathNestedRpc_1, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
 		closeNotifier, ok := w.(http.CloseNotifier)
 		if ok {
 			go func() {
-				<-closeNotifier.CloseNotify()
-				cancel()
+				select {
+				case <-ctx.Done():
+				case <-closeNotifier.CloseNotify():
+					cancel()
+				}
 			}()
 		}
 		resp, md, err := request_FlowCombination_RpcPathNestedRpc_1(runtime.AnnotateContext(ctx, req), client, req, pathParams)
@@ -1285,11 +1341,15 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 
 	mux.Handle("POST", pattern_FlowCombination_RpcPathNestedRpc_2, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
 		closeNotifier, ok := w.(http.CloseNotifier)
 		if ok {
 			go func() {
-				<-closeNotifier.CloseNotify()
-				cancel()
+				select {
+				case <-ctx.Done():
+				case <-closeNotifier.CloseNotify():
+					cancel()
+				}
 			}()
 		}
 		resp, md, err := request_FlowCombination_RpcPathNestedRpc_2(runtime.AnnotateContext(ctx, req), client, req, pathParams)
@@ -1305,11 +1365,15 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 
 	mux.Handle("POST", pattern_FlowCombination_RpcBodyStream_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
 		closeNotifier, ok := w.(http.CloseNotifier)
 		if ok {
 			go func() {
-				<-closeNotifier.CloseNotify()
-				cancel()
+				select {
+				case <-ctx.Done():
+				case <-closeNotifier.CloseNotify():
+					cancel()
+				}
 			}()
 		}
 		resp, md, err := request_FlowCombination_RpcBodyStream_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
@@ -1325,11 +1389,15 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 
 	mux.Handle("POST", pattern_FlowCombination_RpcBodyStream_1, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
 		closeNotifier, ok := w.(http.CloseNotifier)
 		if ok {
 			go func() {
-				<-closeNotifier.CloseNotify()
-				cancel()
+				select {
+				case <-ctx.Done():
+				case <-closeNotifier.CloseNotify():
+					cancel()
+				}
 			}()
 		}
 		resp, md, err := request_FlowCombination_RpcBodyStream_1(runtime.AnnotateContext(ctx, req), client, req, pathParams)
@@ -1345,11 +1413,15 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 
 	mux.Handle("POST", pattern_FlowCombination_RpcBodyStream_2, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
 		closeNotifier, ok := w.(http.CloseNotifier)
 		if ok {
 			go func() {
-				<-closeNotifier.CloseNotify()
-				cancel()
+				select {
+				case <-ctx.Done():
+				case <-closeNotifier.CloseNotify():
+					cancel()
+				}
 			}()
 		}
 		resp, md, err := request_FlowCombination_RpcBodyStream_2(runtime.AnnotateContext(ctx, req), client, req, pathParams)
@@ -1365,11 +1437,15 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 
 	mux.Handle("POST", pattern_FlowCombination_RpcBodyStream_3, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
 		closeNotifier, ok := w.(http.CloseNotifier)
 		if ok {
 			go func() {
-				<-closeNotifier.CloseNotify()
-				cancel()
+				select {
+				case <-ctx.Done():
+				case <-closeNotifier.CloseNotify():
+					cancel()
+				}
 			}()
 		}
 		resp, md, err := request_FlowCombination_RpcBodyStream_3(runtime.AnnotateContext(ctx, req), client, req, pathParams)
@@ -1385,11 +1461,15 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 
 	mux.Handle("POST", pattern_FlowCombination_RpcBodyStream_4, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
 		closeNotifier, ok := w.(http.CloseNotifier)
 		if ok {
 			go func() {
-				<-closeNotifier.CloseNotify()
-				cancel()
+				select {
+				case <-ctx.Done():
+				case <-closeNotifier.CloseNotify():
+					cancel()
+				}
 			}()
 		}
 		resp, md, err := request_FlowCombination_RpcBodyStream_4(runtime.AnnotateContext(ctx, req), client, req, pathParams)
@@ -1405,11 +1485,15 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 
 	mux.Handle("POST", pattern_FlowCombination_RpcBodyStream_5, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
 		closeNotifier, ok := w.(http.CloseNotifier)
 		if ok {
 			go func() {
-				<-closeNotifier.CloseNotify()
-				cancel()
+				select {
+				case <-ctx.Done():
+				case <-closeNotifier.CloseNotify():
+					cancel()
+				}
 			}()
 		}
 		resp, md, err := request_FlowCombination_RpcBodyStream_5(runtime.AnnotateContext(ctx, req), client, req, pathParams)
@@ -1425,11 +1509,15 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 
 	mux.Handle("POST", pattern_FlowCombination_RpcBodyStream_6, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
 		closeNotifier, ok := w.(http.CloseNotifier)
 		if ok {
 			go func() {
-				<-closeNotifier.CloseNotify()
-				cancel()
+				select {
+				case <-ctx.Done():
+				case <-closeNotifier.CloseNotify():
+					cancel()
+				}
 			}()
 		}
 		resp, md, err := request_FlowCombination_RpcBodyStream_6(runtime.AnnotateContext(ctx, req), client, req, pathParams)
@@ -1445,11 +1533,15 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 
 	mux.Handle("POST", pattern_FlowCombination_RpcPathSingleNestedStream_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
 		closeNotifier, ok := w.(http.CloseNotifier)
 		if ok {
 			go func() {
-				<-closeNotifier.CloseNotify()
-				cancel()
+				select {
+				case <-ctx.Done():
+				case <-closeNotifier.CloseNotify():
+					cancel()
+				}
 			}()
 		}
 		resp, md, err := request_FlowCombination_RpcPathSingleNestedStream_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
@@ -1465,11 +1557,15 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 
 	mux.Handle("POST", pattern_FlowCombination_RpcPathNestedStream_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
 		closeNotifier, ok := w.(http.CloseNotifier)
 		if ok {
 			go func() {
-				<-closeNotifier.CloseNotify()
-				cancel()
+				select {
+				case <-ctx.Done():
+				case <-closeNotifier.CloseNotify():
+					cancel()
+				}
 			}()
 		}
 		resp, md, err := request_FlowCombination_RpcPathNestedStream_0(runtime.AnnotateContext(ctx, req), client, req, pathParams)
@@ -1485,11 +1581,15 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 
 	mux.Handle("POST", pattern_FlowCombination_RpcPathNestedStream_1, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
 		closeNotifier, ok := w.(http.CloseNotifier)
 		if ok {
 			go func() {
-				<-closeNotifier.CloseNotify()
-				cancel()
+				select {
+				case <-ctx.Done():
+				case <-closeNotifier.CloseNotify():
+					cancel()
+				}
 			}()
 		}
 		resp, md, err := request_FlowCombination_RpcPathNestedStream_1(runtime.AnnotateContext(ctx, req), client, req, pathParams)
@@ -1505,11 +1605,15 @@ func RegisterFlowCombinationHandler(ctx context.Context, mux *runtime.ServeMux, 
 
 	mux.Handle("POST", pattern_FlowCombination_RpcPathNestedStream_2, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
 		closeNotifier, ok := w.(http.CloseNotifier)
 		if ok {
 			go func() {
-				<-closeNotifier.CloseNotify()
-				cancel()
+				select {
+				case <-ctx.Done():
+				case <-closeNotifier.CloseNotify():
+					cancel()
+				}
 			}()
 		}
 		resp, md, err := request_FlowCombination_RpcPathNestedStream_2(runtime.AnnotateContext(ctx, req), client, req, pathParams)


### PR DESCRIPTION
`CloseNotifier` channel is triggered only if the connection is closed,
the goroutines for earlier requests used to remain until the last
request closes the connection when HTTP keep-alive is used.

This commit terminates the groutine as soon as its corresponding HTTP
request is done.

I'm not sure but it might fix #115.