### PR TITLE
Replace glog with grpclog

### DIFF
--- a/examples/examplepb/a_bit_of_everything.pb.gw.go
+++ b/examples/examplepb/a_bit_of_everything.pb.gw.go
@@ -17,11 +17,11 @@ import (
 	"github.com/gengo/grpc-gateway/examples/sub"
 	"github.com/gengo/grpc-gateway/runtime"
 	"github.com/gengo/grpc-gateway/utilities"
-	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/grpclog"
 )
 
 var _ codes.Code
@@ -225,7 +225,7 @@ func request_ABitOfEverythingService_BulkCreate_0(ctx context.Context, client AB
 	var metadata runtime.ServerMetadata
 	stream, err := client.BulkCreate(ctx)
 	if err != nil {
-		glog.Errorf("Failed to start streaming: %v", err)
+		grpclog.Printf("Failed to start streaming: %v", err)
 		return nil, metadata, err
 	}
 	dec := json.NewDecoder(req.Body)
@@ -236,22 +236,22 @@ func request_ABitOfEverythingService_BulkCreate_0(ctx context.Context, client AB
 			break
 		}
 		if err != nil {
-			glog.Errorf("Failed to decode request: %v", err)
+			grpclog.Printf("Failed to decode request: %v", err)
 			return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
 		}
 		if err = stream.Send(&protoReq); err != nil {
-			glog.Errorf("Failed to send request: %v", err)
+			grpclog.Printf("Failed to send request: %v", err)
 			return nil, metadata, err
 		}
 	}
 
 	if err := stream.CloseSend(); err != nil {
-		glog.Errorf("Failed to terminate client stream: %v", err)
+		grpclog.Printf("Failed to terminate client stream: %v", err)
 		return nil, metadata, err
 	}
 	header, err := stream.Header()
 	if err != nil {
-		glog.Errorf("Failed to get header from client: %v", err)
+		grpclog.Printf("Failed to get header from client: %v", err)
 		return nil, metadata, err
 	}
 	metadata.HeaderMD = header
@@ -425,7 +425,7 @@ func request_ABitOfEverythingService_BulkEcho_0(ctx context.Context, client ABit
 	var metadata runtime.ServerMetadata
 	stream, err := client.BulkEcho(ctx)
 	if err != nil {
-		glog.Errorf("Failed to start streaming: %v", err)
+		grpclog.Printf("Failed to start streaming: %v", err)
 		return nil, metadata, err
 	}
 	dec := json.NewDecoder(req.Body)
@@ -436,22 +436,22 @@ func request_ABitOfEverythingService_BulkEcho_0(ctx context.Context, client ABit
 			break
 		}
 		if err != nil {
-			glog.Errorf("Failed to decode request: %v", err)
+			grpclog.Printf("Failed to decode request: %v", err)
 			return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
 		}
 		if err = stream.Send(&protoReq); err != nil {
-			glog.Errorf("Failed to send request: %v", err)
+			grpclog.Printf("Failed to send request: %v", err)
 			return nil, metadata, err
 		}
 	}
 
 	if err := stream.CloseSend(); err != nil {
-		glog.Errorf("Failed to terminate client stream: %v", err)
+		grpclog.Printf("Failed to terminate client stream: %v", err)
 		return nil, metadata, err
 	}
 	header, err := stream.Header()
 	if err != nil {
-		glog.Errorf("Failed to get header from client: %v", err)
+		grpclog.Printf("Failed to get header from client: %v", err)
 		return nil, metadata, err
 	}
 	metadata.HeaderMD = header
@@ -470,14 +470,14 @@ func RegisterABitOfEverythingServiceHandlerFromEndpoint(ctx context.Context, mux
 	defer func() {
 		if err != nil {
 			if cerr := conn.Close(); cerr != nil {
-				glog.Errorf("Failed to close conn to %s: %v", endpoint, cerr)
+				grpclog.Printf("Failed to close conn to %s: %v", endpoint, cerr)
 			}
 			return
 		}
 		go func() {
 			<-ctx.Done()
 			if cerr := conn.Close(); cerr != nil {
-				glog.Errorf("Failed to close conn to %s: %v", endpoint, cerr)
+				grpclog.Printf("Failed to close conn to %s: %v", endpoint, cerr)
 			}
 		}()
 	}()

--- a/examples/examplepb/echo_service.pb.gw.go
+++ b/examples/examplepb/echo_service.pb.gw.go
@@ -16,11 +16,11 @@ import (
 
 	"github.com/gengo/grpc-gateway/runtime"
 	"github.com/gengo/grpc-gateway/utilities"
-	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/grpclog"
 )
 
 var _ codes.Code
@@ -79,14 +79,14 @@ func RegisterEchoServiceHandlerFromEndpoint(ctx context.Context, mux *runtime.Se
 	defer func() {
 		if err != nil {
 			if cerr := conn.Close(); cerr != nil {
-				glog.Errorf("Failed to close conn to %s: %v", endpoint, cerr)
+				grpclog.Printf("Failed to close conn to %s: %v", endpoint, cerr)
 			}
 			return
 		}
 		go func() {
 			<-ctx.Done()
 			if cerr := conn.Close(); cerr != nil {
-				glog.Errorf("Failed to close conn to %s: %v", endpoint, cerr)
+				grpclog.Printf("Failed to close conn to %s: %v", endpoint, cerr)
 			}
 		}()
 	}()

--- a/examples/examplepb/flow_combination.pb.gw.go
+++ b/examples/examplepb/flow_combination.pb.gw.go
@@ -16,11 +16,11 @@ import (
 
 	"github.com/gengo/grpc-gateway/runtime"
 	"github.com/gengo/grpc-gateway/utilities"
-	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/grpclog"
 )
 
 var _ codes.Code
@@ -59,7 +59,7 @@ func request_FlowCombination_StreamEmptyRpc_0(ctx context.Context, client FlowCo
 	var metadata runtime.ServerMetadata
 	stream, err := client.StreamEmptyRpc(ctx)
 	if err != nil {
-		glog.Errorf("Failed to start streaming: %v", err)
+		grpclog.Printf("Failed to start streaming: %v", err)
 		return nil, metadata, err
 	}
 	dec := json.NewDecoder(req.Body)
@@ -70,22 +70,22 @@ func request_FlowCombination_StreamEmptyRpc_0(ctx context.Context, client FlowCo
 			break
 		}
 		if err != nil {
-			glog.Errorf("Failed to decode request: %v", err)
+			grpclog.Printf("Failed to decode request: %v", err)
 			return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
 		}
 		if err = stream.Send(&protoReq); err != nil {
-			glog.Errorf("Failed to send request: %v", err)
+			grpclog.Printf("Failed to send request: %v", err)
 			return nil, metadata, err
 		}
 	}
 
 	if err := stream.CloseSend(); err != nil {
-		glog.Errorf("Failed to terminate client stream: %v", err)
+		grpclog.Printf("Failed to terminate client stream: %v", err)
 		return nil, metadata, err
 	}
 	header, err := stream.Header()
 	if err != nil {
-		glog.Errorf("Failed to get header from client: %v", err)
+		grpclog.Printf("Failed to get header from client: %v", err)
 		return nil, metadata, err
 	}
 	metadata.HeaderMD = header
@@ -100,7 +100,7 @@ func request_FlowCombination_StreamEmptyStream_0(ctx context.Context, client Flo
 	var metadata runtime.ServerMetadata
 	stream, err := client.StreamEmptyStream(ctx)
 	if err != nil {
-		glog.Errorf("Failed to start streaming: %v", err)
+		grpclog.Printf("Failed to start streaming: %v", err)
 		return nil, metadata, err
 	}
 	dec := json.NewDecoder(req.Body)
@@ -111,22 +111,22 @@ func request_FlowCombination_StreamEmptyStream_0(ctx context.Context, client Flo
 			break
 		}
 		if err != nil {
-			glog.Errorf("Failed to decode request: %v", err)
+			grpclog.Printf("Failed to decode request: %v", err)
 			return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
 		}
 		if err = stream.Send(&protoReq); err != nil {
-			glog.Errorf("Failed to send request: %v", err)
+			grpclog.Printf("Failed to send request: %v", err)
 			return nil, metadata, err
 		}
 	}
 
 	if err := stream.CloseSend(); err != nil {
-		glog.Errorf("Failed to terminate client stream: %v", err)
+		grpclog.Printf("Failed to terminate client stream: %v", err)
 		return nil, metadata, err
 	}
 	header, err := stream.Header()
 	if err != nil {
-		glog.Errorf("Failed to get header from client: %v", err)
+		grpclog.Printf("Failed to get header from client: %v", err)
 		return nil, metadata, err
 	}
 	metadata.HeaderMD = header
@@ -983,14 +983,14 @@ func RegisterFlowCombinationHandlerFromEndpoint(ctx context.Context, mux *runtim
 	defer func() {
 		if err != nil {
 			if cerr := conn.Close(); cerr != nil {
-				glog.Errorf("Failed to close conn to %s: %v", endpoint, cerr)
+				grpclog.Printf("Failed to close conn to %s: %v", endpoint, cerr)
 			}
 			return
 		}
 		go func() {
 			<-ctx.Done()
 			if cerr := conn.Close(); cerr != nil {
-				glog.Errorf("Failed to close conn to %s: %v", endpoint, cerr)
+				grpclog.Printf("Failed to close conn to %s: %v", endpoint, cerr)
 			}
 		}()
 	}()

--- a/protoc-gen-grpc-gateway/gengateway/generator.go
+++ b/protoc-gen-grpc-gateway/gengateway/generator.go
@@ -33,11 +33,11 @@ func New(reg *descriptor.Registry) gen.Generator {
 		"net/http",
 		"github.com/gengo/grpc-gateway/runtime",
 		"github.com/gengo/grpc-gateway/utilities",
-		"github.com/golang/glog",
 		"github.com/golang/protobuf/proto",
 		"golang.org/x/net/context",
 		"google.golang.org/grpc",
 		"google.golang.org/grpc/codes",
+		"google.golang.org/grpc/grpclog",
 	} {
 		pkg := descriptor.GoPackage{
 			Path: pkgpath,

--- a/protoc-gen-grpc-gateway/gengateway/template.go
+++ b/protoc-gen-grpc-gateway/gengateway/template.go
@@ -137,7 +137,7 @@ func request_{{.Method.Service.GetName}}_{{.Method.GetName}}_{{.Index}}(ctx cont
 	var metadata runtime.ServerMetadata
 	stream, err := client.{{.Method.GetName}}(ctx)
 	if err != nil {
-		glog.Errorf("Failed to start streaming: %v", err)
+		grpclog.Printf("Failed to start streaming: %v", err)
 		return nil, metadata, err
 	}
 	dec := json.NewDecoder(req.Body)
@@ -148,22 +148,22 @@ func request_{{.Method.Service.GetName}}_{{.Method.GetName}}_{{.Index}}(ctx cont
 			break
 		}
 		if err != nil {
-			glog.Errorf("Failed to decode request: %v", err)
+			grpclog.Printf("Failed to decode request: %v", err)
 			return nil, metadata, grpc.Errorf(codes.InvalidArgument, "%v", err)
 		}
 		if err = stream.Send(&protoReq); err != nil {
-			glog.Errorf("Failed to send request: %v", err)
+			grpclog.Printf("Failed to send request: %v", err)
 			return nil, metadata, err
 		}
 	}
 
 	if err := stream.CloseSend(); err != nil {
-		glog.Errorf("Failed to terminate client stream: %v", err)
+		grpclog.Printf("Failed to terminate client stream: %v", err)
 		return nil, metadata, err
 	}
 	header, err := stream.Header()
 	if err != nil {
-		glog.Errorf("Failed to get header from client: %v", err)
+		grpclog.Printf("Failed to get header from client: %v", err)
 		return nil, metadata, err
 	}
 	metadata.HeaderMD = header
@@ -247,14 +247,14 @@ func Register{{$svc.GetName}}HandlerFromEndpoint(ctx context.Context, mux *runti
 	defer func() {
 		if err != nil {
 			if cerr := conn.Close(); cerr != nil {
-				glog.Errorf("Failed to close conn to %s: %v", endpoint, cerr)
+				grpclog.Printf("Failed to close conn to %s: %v", endpoint, cerr)
 			}
 			return
 		}
 		go func() {
 			<-ctx.Done()
 			if cerr := conn.Close(); cerr != nil {
-				glog.Errorf("Failed to close conn to %s: %v", endpoint, cerr)
+				grpclog.Printf("Failed to close conn to %s: %v", endpoint, cerr)
 			}
 		}()
 	}()

--- a/runtime/mux.go
+++ b/runtime/mux.go
@@ -6,7 +6,6 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
 )
 
@@ -82,7 +81,6 @@ func (s *ServeMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	for _, h := range s.handlers[r.Method] {
 		pathParams, err := h.pat.Match(components, verb)
 		if err != nil {
-			glog.V(3).Infof("path mismatch: %q to %q", path, h.pat)
 			continue
 		}
 		h.h(w, r, pathParams)

--- a/runtime/pattern.go
+++ b/runtime/pattern.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/gengo/grpc-gateway/utilities"
-	"github.com/golang/glog"
+	"google.golang.org/grpc/grpclog"
 )
 
 var (
@@ -44,13 +44,13 @@ type Pattern struct {
 // It returns an error if the given definition is invalid.
 func NewPattern(version int, ops []int, pool []string, verb string) (Pattern, error) {
 	if version != 1 {
-		glog.V(2).Infof("unsupported version: %d", version)
+		grpclog.Printf("unsupported version: %d", version)
 		return Pattern{}, ErrInvalidPattern
 	}
 
 	l := len(ops)
 	if l%2 != 0 {
-		glog.V(2).Infof("odd number of ops codes: %d", l)
+		grpclog.Printf("odd number of ops codes: %d", l)
 		return Pattern{}, ErrInvalidPattern
 	}
 
@@ -73,14 +73,14 @@ func NewPattern(version int, ops []int, pool []string, verb string) (Pattern, er
 			stack++
 		case utilities.OpPushM:
 			if pushMSeen {
-				glog.V(2).Info("pushM appears twice")
+				grpclog.Printf("pushM appears twice")
 				return Pattern{}, ErrInvalidPattern
 			}
 			pushMSeen = true
 			stack++
 		case utilities.OpLitPush:
 			if op.operand < 0 || len(pool) <= op.operand {
-				glog.V(2).Infof("negative literal index: %d", op.operand)
+				grpclog.Printf("negative literal index: %d", op.operand)
 				return Pattern{}, ErrInvalidPattern
 			}
 			if pushMSeen {
@@ -89,18 +89,18 @@ func NewPattern(version int, ops []int, pool []string, verb string) (Pattern, er
 			stack++
 		case utilities.OpConcatN:
 			if op.operand <= 0 {
-				glog.V(2).Infof("negative concat size: %d", op.operand)
+				grpclog.Printf("negative concat size: %d", op.operand)
 				return Pattern{}, ErrInvalidPattern
 			}
 			stack -= op.operand
 			if stack < 0 {
-				glog.V(2).Info("stack underflow")
+				grpclog.Print("stack underflow")
 				return Pattern{}, ErrInvalidPattern
 			}
 			stack++
 		case utilities.OpCapture:
 			if op.operand < 0 || len(pool) <= op.operand {
-				glog.V(2).Infof("variable name index out of bound: %d", op.operand)
+				grpclog.Printf("variable name index out of bound: %d", op.operand)
 				return Pattern{}, ErrInvalidPattern
 			}
 			v := pool[op.operand]
@@ -108,11 +108,11 @@ func NewPattern(version int, ops []int, pool []string, verb string) (Pattern, er
 			vars = append(vars, v)
 			stack--
 			if stack < 0 {
-				glog.V(2).Info("stack underflow")
+				grpclog.Printf("stack underflow")
 				return Pattern{}, ErrInvalidPattern
 			}
 		default:
-			glog.V(2).Infof("invalid opcode: %d", op.code)
+			grpclog.Printf("invalid opcode: %d", op.code)
 			return Pattern{}, ErrInvalidPattern
 		}
 
@@ -121,7 +121,6 @@ func NewPattern(version int, ops []int, pool []string, verb string) (Pattern, er
 		}
 		typedOps = append(typedOps, op)
 	}
-	glog.V(3).Info("pattern successfully built")
 	return Pattern{
 		ops:       typedOps,
 		pool:      pool,
@@ -135,7 +134,7 @@ func NewPattern(version int, ops []int, pool []string, verb string) (Pattern, er
 // MustPattern is a helper function which makes it easier to call NewPattern in variable initialization.
 func MustPattern(p Pattern, err error) Pattern {
 	if err != nil {
-		glog.Fatalf("Pattern initialization failed: %v", err)
+		grpclog.Fatalf("Pattern initialization failed: %v", err)
 	}
 	return p
 }
@@ -144,8 +143,6 @@ func MustPattern(p Pattern, err error) Pattern {
 // If it matches, the function returns a mapping from field paths to their captured values.
 // If otherwise, the function returns an error.
 func (p Pattern) Match(components []string, verb string) (map[string]string, error) {
-	glog.V(2).Infof("matching (%q, %q) to %v", components, verb, p)
-
 	if p.verb != verb {
 		return nil, ErrNotMatch
 	}
@@ -160,13 +157,11 @@ func (p Pattern) Match(components []string, verb string) (map[string]string, err
 			continue
 		case utilities.OpPush, utilities.OpLitPush:
 			if pos >= l {
-				glog.V(1).Infof("insufficient # of segments")
 				return nil, ErrNotMatch
 			}
 			c := components[pos]
 			if op.code == utilities.OpLitPush {
 				if lit := p.pool[op.operand]; c != lit {
-					glog.V(1).Infof("literal segment mismatch: got %q; want %q", c, lit)
 					return nil, ErrNotMatch
 				}
 			}
@@ -191,7 +186,6 @@ func (p Pattern) Match(components []string, verb string) (map[string]string, err
 		}
 	}
 	if pos < l {
-		glog.V(1).Infof("remaining segments: %q", components[pos:])
 		return nil, ErrNotMatch
 	}
 	bindings := make(map[string]string)

--- a/runtime/query.go
+++ b/runtime/query.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 
 	"github.com/gengo/grpc-gateway/utilities"
-	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
+	"google.golang.org/grpc/grpclog"
 )
 
 // PopulateQueryParameters populates "values" into "msg".
@@ -46,7 +46,7 @@ func populateFieldValueFromPath(msg proto.Message, fieldPath []string, values []
 		}
 		f := fieldByProtoName(m, fieldName)
 		if !f.IsValid() {
-			glog.Warningf("field not found in %T: %s", msg, strings.Join(fieldPath, "."))
+			grpclog.Printf("field not found in %T: %s", msg, strings.Join(fieldPath, "."))
 			return nil
 		}
 
@@ -78,7 +78,7 @@ func populateFieldValueFromPath(msg proto.Message, fieldPath []string, values []
 		return fmt.Errorf("no value of field: %s", strings.Join(fieldPath, "."))
 	case 1:
 	default:
-		glog.Warningf("too many field values: %s", strings.Join(fieldPath, "."))
+		grpclog.Printf("too many field values: %s", strings.Join(fieldPath, "."))
 	}
 	return populateField(m, values[0])
 }


### PR DESCRIPTION
This allows projects with forked versions of `glog` (e.g. CockroachDB) to use `grpc-gateway` without a flag collision (runtime panic) on the `glog` flags such as `-logtostderr`. This also allows integration with any logging systems that have been integrated with `grpclog`.

Note that I only replaced `glog` in the `runtime` package and in the files generated by `protoc-gen-grpc-gateway`. The use of `glog` elsewhere in this repo doesn't seem to affect ability to use `grpc-gateway` in projects with forked `glog` versions.

Fixes #92.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/gengo/grpc-gateway/118)
<!-- Reviewable:end -->
