### PR TITLE
Generate Swagger description for service methods using proto comments.

### DIFF
--- a/examples/examplepb/a_bit_of_everything.pb.go
+++ b/examples/examplepb/a_bit_of_everything.pb.go
@@ -132,7 +132,7 @@ var _ grpc.ClientConn
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion1
+const _ = grpc.SupportPackageIsVersion2
 
 // Client API for ABitOfEverythingService service
 
@@ -325,28 +325,40 @@ func RegisterABitOfEverythingServiceServer(s *grpc.Server, srv ABitOfEverythingS
 	s.RegisterService(&_ABitOfEverythingService_serviceDesc, srv)
 }
 
-func _ABitOfEverythingService_Create_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error) (interface{}, error) {
+func _ABitOfEverythingService_Create_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(ABitOfEverything)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
-	out, err := srv.(ABitOfEverythingServiceServer).Create(ctx, in)
-	if err != nil {
-		return nil, err
+	if interceptor == nil {
+		return srv.(ABitOfEverythingServiceServer).Create(ctx, in)
 	}
-	return out, nil
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/gengo.grpc.gateway.examples.examplepb.ABitOfEverythingService/Create",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ABitOfEverythingServiceServer).Create(ctx, req.(*ABitOfEverything))
+	}
+	return interceptor(ctx, in, info, handler)
 }
 
-func _ABitOfEverythingService_CreateBody_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error) (interface{}, error) {
+func _ABitOfEverythingService_CreateBody_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(ABitOfEverything)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
-	out, err := srv.(ABitOfEverythingServiceServer).CreateBody(ctx, in)
-	if err != nil {
-		return nil, err
+	if interceptor == nil {
+		return srv.(ABitOfEverythingServiceServer).CreateBody(ctx, in)
 	}
-	return out, nil
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/gengo.grpc.gateway.examples.examplepb.ABitOfEverythingService/CreateBody",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ABitOfEverythingServiceServer).CreateBody(ctx, req.(*ABitOfEverything))
+	}
+	return interceptor(ctx, in, info, handler)
 }
 
 func _ABitOfEverythingService_BulkCreate_Handler(srv interface{}, stream grpc.ServerStream) error {
@@ -375,16 +387,22 @@ func (x *aBitOfEverythingServiceBulkCreateServer) Recv() (*ABitOfEverything, err
 	return m, nil
 }
 
-func _ABitOfEverythingService_Lookup_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error) (interface{}, error) {
+func _ABitOfEverythingService_Lookup_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(sub2.IdMessage)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
-	out, err := srv.(ABitOfEverythingServiceServer).Lookup(ctx, in)
-	if err != nil {
-		return nil, err
+	if interceptor == nil {
+		return srv.(ABitOfEverythingServiceServer).Lookup(ctx, in)
 	}
-	return out, nil
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/gengo.grpc.gateway.examples.examplepb.ABitOfEverythingService/Lookup",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ABitOfEverythingServiceServer).Lookup(ctx, req.(*sub2.IdMessage))
+	}
+	return interceptor(ctx, in, info, handler)
 }
 
 func _ABitOfEverythingService_List_Handler(srv interface{}, stream grpc.ServerStream) error {
@@ -408,40 +426,58 @@ func (x *aBitOfEverythingServiceListServer) Send(m *ABitOfEverything) error {
 	return x.ServerStream.SendMsg(m)
 }
 
-func _ABitOfEverythingService_Update_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error) (interface{}, error) {
+func _ABitOfEverythingService_Update_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(ABitOfEverything)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
-	out, err := srv.(ABitOfEverythingServiceServer).Update(ctx, in)
-	if err != nil {
-		return nil, err
+	if interceptor == nil {
+		return srv.(ABitOfEverythingServiceServer).Update(ctx, in)
 	}
-	return out, nil
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/gengo.grpc.gateway.examples.examplepb.ABitOfEverythingService/Update",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ABitOfEverythingServiceServer).Update(ctx, req.(*ABitOfEverything))
+	}
+	return interceptor(ctx, in, info, handler)
 }
 
-func _ABitOfEverythingService_Delete_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error) (interface{}, error) {
+func _ABitOfEverythingService_Delete_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(sub2.IdMessage)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
-	out, err := srv.(ABitOfEverythingServiceServer).Delete(ctx, in)
-	if err != nil {
-		return nil, err
+	if interceptor == nil {
+		return srv.(ABitOfEverythingServiceServer).Delete(ctx, in)
 	}
-	return out, nil
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/gengo.grpc.gateway.examples.examplepb.ABitOfEverythingService/Delete",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ABitOfEverythingServiceServer).Delete(ctx, req.(*sub2.IdMessage))
+	}
+	return interceptor(ctx, in, info, handler)
 }
 
-func _ABitOfEverythingService_Echo_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error) (interface{}, error) {
+func _ABitOfEverythingService_Echo_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(gengo_grpc_gateway_examples_sub.StringMessage)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
-	out, err := srv.(ABitOfEverythingServiceServer).Echo(ctx, in)
-	if err != nil {
-		return nil, err
+	if interceptor == nil {
+		return srv.(ABitOfEverythingServiceServer).Echo(ctx, in)
 	}
-	return out, nil
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/gengo.grpc.gateway.examples.examplepb.ABitOfEverythingService/Echo",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ABitOfEverythingServiceServer).Echo(ctx, req.(*gengo_grpc_gateway_examples_sub.StringMessage))
+	}
+	return interceptor(ctx, in, info, handler)
 }
 
 func _ABitOfEverythingService_BulkEcho_Handler(srv interface{}, stream grpc.ServerStream) error {

--- a/examples/examplepb/echo_service.pb.go
+++ b/examples/examplepb/echo_service.pb.go
@@ -10,25 +10,6 @@ Echo Service
 Echo Service API consists of a single service which returns
 a message.
 
-<!-- swagger extras start
-{
-  "info": {
-    "title": "Echo Service",
-    "version": "1.0",
-    "contact": {
-      "name": "gRPC-Gateway project",
-      "url": "https://github.com/gengo/grpc-gateway",
-      "email": "none@example.com"
-    }
-  },
-  "host": "localhost",
-  "externalDocs": {
-    "url": "https://github.com/gengo/grpc-gateway",
-    "description": "More about gRPC-Gateway"
-  }
-}
-swagger extras end -->
-
 It is generated from these files:
 	examples/examplepb/echo_service.proto
 	examples/examplepb/a_bit_of_everything.proto
@@ -66,15 +47,6 @@ var _ = math.Inf
 const _ = proto.ProtoPackageIsVersion1
 
 // SimpleMessage represents a simple message sent to the Echo service.
-//
-// <!-- swagger extras start
-// {
-//   "externalDocs": {
-//     "url": "http://github.com/gengo/grpc-gateway",
-//     "description": "Find out more about EchoService"
-//   }
-// }
-// swagger extras end -->
 type SimpleMessage struct {
 	// Id represents the message identifier.
 	Id string `protobuf:"bytes,1,opt,name=id" json:"id,omitempty"`
@@ -104,15 +76,6 @@ type EchoServiceClient interface {
 	//
 	// The message posted as the id parameter will also be
 	// returned.
-	//
-	// <!-- swagger extras start
-	// {
-	//   "externalDocs": {
-	//     "url": "http://github.com/gengo/grpc-gateway",
-	//     "description": "Find out more about EchoService"
-	//   }
-	// }
-	// swagger extras end -->
 	Echo(ctx context.Context, in *SimpleMessage, opts ...grpc.CallOption) (*SimpleMessage, error)
 	// EchoBody method receives a simple message and returns it.
 	EchoBody(ctx context.Context, in *SimpleMessage, opts ...grpc.CallOption) (*SimpleMessage, error)
@@ -151,15 +114,6 @@ type EchoServiceServer interface {
 	//
 	// The message posted as the id parameter will also be
 	// returned.
-	//
-	// <!-- swagger extras start
-	// {
-	//   "externalDocs": {
-	//     "url": "http://github.com/gengo/grpc-gateway",
-	//     "description": "Find out more about EchoService"
-	//   }
-	// }
-	// swagger extras end -->
 	Echo(context.Context, *SimpleMessage) (*SimpleMessage, error)
 	// EchoBody method receives a simple message and returns it.
 	EchoBody(context.Context, *SimpleMessage) (*SimpleMessage, error)

--- a/examples/examplepb/echo_service.pb.go
+++ b/examples/examplepb/echo_service.pb.go
@@ -41,7 +41,9 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 const _ = proto.ProtoPackageIsVersion1
 
+// SimpleMessage represents a simple message sent to the Echo service.
 type SimpleMessage struct {
+	// Id represents the message identifier.
 	Id string `protobuf:"bytes,1,opt,name=id" json:"id,omitempty"`
 }
 
@@ -60,12 +62,14 @@ var _ grpc.ClientConn
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion1
+const _ = grpc.SupportPackageIsVersion2
 
 // Client API for EchoService service
 
 type EchoServiceClient interface {
+	// Echo method receives a simple message and returns it.
 	Echo(ctx context.Context, in *SimpleMessage, opts ...grpc.CallOption) (*SimpleMessage, error)
+	// EchoBody method receives a simple message and returns it.
 	EchoBody(ctx context.Context, in *SimpleMessage, opts ...grpc.CallOption) (*SimpleMessage, error)
 }
 
@@ -98,7 +102,9 @@ func (c *echoServiceClient) EchoBody(ctx context.Context, in *SimpleMessage, opt
 // Server API for EchoService service
 
 type EchoServiceServer interface {
+	// Echo method receives a simple message and returns it.
 	Echo(context.Context, *SimpleMessage) (*SimpleMessage, error)
+	// EchoBody method receives a simple message and returns it.
 	EchoBody(context.Context, *SimpleMessage) (*SimpleMessage, error)
 }
 
@@ -106,28 +112,40 @@ func RegisterEchoServiceServer(s *grpc.Server, srv EchoServiceServer) {
 	s.RegisterService(&_EchoService_serviceDesc, srv)
 }
 
-func _EchoService_Echo_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error) (interface{}, error) {
+func _EchoService_Echo_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(SimpleMessage)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
-	out, err := srv.(EchoServiceServer).Echo(ctx, in)
-	if err != nil {
-		return nil, err
+	if interceptor == nil {
+		return srv.(EchoServiceServer).Echo(ctx, in)
 	}
-	return out, nil
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/gengo.grpc.gateway.examples.examplepb.EchoService/Echo",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(EchoServiceServer).Echo(ctx, req.(*SimpleMessage))
+	}
+	return interceptor(ctx, in, info, handler)
 }
 
-func _EchoService_EchoBody_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error) (interface{}, error) {
+func _EchoService_EchoBody_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(SimpleMessage)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
-	out, err := srv.(EchoServiceServer).EchoBody(ctx, in)
-	if err != nil {
-		return nil, err
+	if interceptor == nil {
+		return srv.(EchoServiceServer).EchoBody(ctx, in)
 	}
-	return out, nil
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/gengo.grpc.gateway.examples.examplepb.EchoService/EchoBody",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(EchoServiceServer).EchoBody(ctx, req.(*SimpleMessage))
+	}
+	return interceptor(ctx, in, info, handler)
 }
 
 var _EchoService_serviceDesc = grpc.ServiceDesc{

--- a/examples/examplepb/echo_service.pb.go
+++ b/examples/examplepb/echo_service.pb.go
@@ -5,6 +5,30 @@
 /*
 Package examplepb is a generated protocol buffer package.
 
+Echo Service
+
+Echo Service API consists of a single service which returns
+a message.
+
+<!-- swagger extras start
+{
+  "info": {
+    "title": "Echo Service",
+    "version": "1.0",
+    "contact": {
+      "name": "gRPC-Gateway project",
+      "url": "https://github.com/gengo/grpc-gateway",
+      "email": "none@example.com"
+    }
+  },
+  "host": "localhost",
+  "externalDocs": {
+    "url": "https://github.com/gengo/grpc-gateway",
+    "description": "More about gRPC-Gateway"
+  }
+}
+swagger extras end -->
+
 It is generated from these files:
 	examples/examplepb/echo_service.proto
 	examples/examplepb/a_bit_of_everything.proto
@@ -42,6 +66,15 @@ var _ = math.Inf
 const _ = proto.ProtoPackageIsVersion1
 
 // SimpleMessage represents a simple message sent to the Echo service.
+//
+// <!-- swagger extras start
+// {
+//   "externalDocs": {
+//     "url": "http://github.com/gengo/grpc-gateway",
+//     "description": "Find out more about EchoService"
+//   }
+// }
+// swagger extras end -->
 type SimpleMessage struct {
 	// Id represents the message identifier.
 	Id string `protobuf:"bytes,1,opt,name=id" json:"id,omitempty"`
@@ -68,6 +101,18 @@ const _ = grpc.SupportPackageIsVersion2
 
 type EchoServiceClient interface {
 	// Echo method receives a simple message and returns it.
+	//
+	// The message posted as the id parameter will also be
+	// returned.
+	//
+	// <!-- swagger extras start
+	// {
+	//   "externalDocs": {
+	//     "url": "http://github.com/gengo/grpc-gateway",
+	//     "description": "Find out more about EchoService"
+	//   }
+	// }
+	// swagger extras end -->
 	Echo(ctx context.Context, in *SimpleMessage, opts ...grpc.CallOption) (*SimpleMessage, error)
 	// EchoBody method receives a simple message and returns it.
 	EchoBody(ctx context.Context, in *SimpleMessage, opts ...grpc.CallOption) (*SimpleMessage, error)
@@ -103,6 +148,18 @@ func (c *echoServiceClient) EchoBody(ctx context.Context, in *SimpleMessage, opt
 
 type EchoServiceServer interface {
 	// Echo method receives a simple message and returns it.
+	//
+	// The message posted as the id parameter will also be
+	// returned.
+	//
+	// <!-- swagger extras start
+	// {
+	//   "externalDocs": {
+	//     "url": "http://github.com/gengo/grpc-gateway",
+	//     "description": "Find out more about EchoService"
+	//   }
+	// }
+	// swagger extras end -->
 	Echo(context.Context, *SimpleMessage) (*SimpleMessage, error)
 	// EchoBody method receives a simple message and returns it.
 	EchoBody(context.Context, *SimpleMessage) (*SimpleMessage, error)

--- a/examples/examplepb/echo_service.proto
+++ b/examples/examplepb/echo_service.proto
@@ -5,39 +5,11 @@ option go_package = "examplepb";
 //
 // Echo Service API consists of a single service which returns
 // a message.
-//
-// <!-- swagger extras start
-// {
-//   "info": {
-//     "title": "Echo Service",
-//     "version": "1.0",
-//     "contact": {
-//       "name": "gRPC-Gateway project",
-//       "url": "https://github.com/gengo/grpc-gateway",
-//       "email": "none@example.com"
-//     }
-//   },
-//   "host": "localhost",
-//   "externalDocs": {
-//     "url": "https://github.com/gengo/grpc-gateway",
-//     "description": "More about gRPC-Gateway"
-//   }
-// }
-// swagger extras end -->
 package gengo.grpc.gateway.examples.examplepb;
 
 import "google/api/annotations.proto";
 
 // SimpleMessage represents a simple message sent to the Echo service.
-//
-// <!-- swagger extras start
-// {
-//   "externalDocs": {
-//     "url": "http://github.com/gengo/grpc-gateway",
-//     "description": "Find out more about EchoService"
-//   }
-// }
-// swagger extras end -->
 message SimpleMessage {
 	// Id represents the message identifier.
 	string id = 1;
@@ -49,15 +21,6 @@ service EchoService {
 	//
 	// The message posted as the id parameter will also be
 	// returned.
-	//
-	// <!-- swagger extras start
-	// {
-	//   "externalDocs": {
-	//     "url": "http://github.com/gengo/grpc-gateway",
-	//     "description": "Find out more about EchoService"
-	//   }
-	// }
-	// swagger extras end -->
 	rpc Echo(SimpleMessage) returns (SimpleMessage) {
 		option (google.api.http) = {
 			post: "/v1/example/echo/{id}"

--- a/examples/examplepb/echo_service.proto
+++ b/examples/examplepb/echo_service.proto
@@ -1,10 +1,43 @@
 syntax = "proto3";
 option go_package = "examplepb";
+
+// Echo Service
+//
+// Echo Service API consists of a single service which returns
+// a message.
+//
+// <!-- swagger extras start
+// {
+//   "info": {
+//     "title": "Echo Service",
+//     "version": "1.0",
+//     "contact": {
+//       "name": "gRPC-Gateway project",
+//       "url": "https://github.com/gengo/grpc-gateway",
+//       "email": "none@example.com"
+//     }
+//   },
+//   "host": "localhost",
+//   "externalDocs": {
+//     "url": "https://github.com/gengo/grpc-gateway",
+//     "description": "More about gRPC-Gateway"
+//   }
+// }
+// swagger extras end -->
 package gengo.grpc.gateway.examples.examplepb;
 
 import "google/api/annotations.proto";
 
-// SimpleMessage represents a simple message sent to the Echo service. 
+// SimpleMessage represents a simple message sent to the Echo service.
+//
+// <!-- swagger extras start
+// {
+//   "externalDocs": {
+//     "url": "http://github.com/gengo/grpc-gateway",
+//     "description": "Find out more about EchoService"
+//   }
+// }
+// swagger extras end -->
 message SimpleMessage {
 	// Id represents the message identifier.
 	string id = 1;
@@ -13,6 +46,18 @@ message SimpleMessage {
 // Echo service responds to incoming echo requests.
 service EchoService {
 	// Echo method receives a simple message and returns it.
+	//
+	// The message posted as the id parameter will also be
+	// returned.
+	//
+	// <!-- swagger extras start
+	// {
+	//   "externalDocs": {
+	//     "url": "http://github.com/gengo/grpc-gateway",
+	//     "description": "Find out more about EchoService"
+	//   }
+	// }
+	// swagger extras end -->
 	rpc Echo(SimpleMessage) returns (SimpleMessage) {
 		option (google.api.http) = {
 			post: "/v1/example/echo/{id}"

--- a/examples/examplepb/echo_service.proto
+++ b/examples/examplepb/echo_service.proto
@@ -4,16 +4,21 @@ package gengo.grpc.gateway.examples.examplepb;
 
 import "google/api/annotations.proto";
 
+// SimpleMessage represents a simple message sent to the Echo service. 
 message SimpleMessage {
+	// Id represents the message identifier.
 	string id = 1;
 }
 
+// Echo service responds to incoming echo requests.
 service EchoService {
+	// Echo method receives a simple message and returns it.
 	rpc Echo(SimpleMessage) returns (SimpleMessage) {
 		option (google.api.http) = {
 			post: "/v1/example/echo/{id}"
 		};
 	}
+	// EchoBody method receives a simple message and returns it.
 	rpc EchoBody(SimpleMessage) returns (SimpleMessage) {
 		option (google.api.http) = {
 			post: "/v1/example/echo_body"

--- a/examples/examplepb/echo_service.swagger.json
+++ b/examples/examplepb/echo_service.swagger.json
@@ -73,6 +73,7 @@
   },
   "definitions": {
     "examplepbSimpleMessage": {
+      "type": "object",
       "properties": {
         "id": {
           "type": "string",

--- a/examples/examplepb/echo_service.swagger.json
+++ b/examples/examplepb/echo_service.swagger.json
@@ -79,7 +79,8 @@
           "format": "string",
           "description": "Id represents the message identifier."
         }
-      }
+      },
+      "description": "SimpleMessage represents a simple message sent to the Echo service."
     }
   }
 }

--- a/examples/examplepb/echo_service.swagger.json
+++ b/examples/examplepb/echo_service.swagger.json
@@ -28,7 +28,7 @@
         "description": "The message posted as the id parameter will also be\nreturned.",
         "operationId": "Echo",
         "responses": {
-          "default": {
+          "200": {
             "description": "Description",
             "schema": {
               "$ref": "#/definitions/examplepbSimpleMessage"
@@ -58,7 +58,7 @@
         "summary": "EchoBody method receives a simple message and returns it.",
         "operationId": "EchoBody",
         "responses": {
-          "default": {
+          "200": {
             "description": "Description",
             "schema": {
               "$ref": "#/definitions/examplepbSimpleMessage"

--- a/examples/examplepb/echo_service.swagger.json
+++ b/examples/examplepb/echo_service.swagger.json
@@ -18,6 +18,7 @@
     "/v1/example/echo/{id}": {
       "post": {
         "summary": "EchoService.Echo",
+        "description": "Echo method receives a simple message and returns it.",
         "operationId": "Echo",
         "responses": {
           "default": {
@@ -44,6 +45,7 @@
     "/v1/example/echo_body": {
       "post": {
         "summary": "EchoService.EchoBody",
+        "description": "EchoBody method receives a simple message and returns it.",
         "operationId": "EchoBody",
         "responses": {
           "default": {

--- a/examples/examplepb/echo_service.swagger.json
+++ b/examples/examplepb/echo_service.swagger.json
@@ -1,9 +1,16 @@
 {
   "swagger": "2.0",
   "info": {
-    "version": "",
-    "title": ""
+    "title": "Echo Service",
+    "description": "Echo Service API consists of a single service which returns\na message.",
+    "version": "1.0",
+    "contact": {
+      "name": "gRPC-Gateway project",
+      "url": "https://github.com/gengo/grpc-gateway",
+      "email": "none@example.com"
+    }
   },
+  "host": "localhost",
   "schemes": [
     "http",
     "https"
@@ -17,8 +24,8 @@
   "paths": {
     "/v1/example/echo/{id}": {
       "post": {
-        "summary": "EchoService.Echo",
-        "description": "Echo method receives a simple message and returns it.",
+        "summary": "Echo method receives a simple message and returns it.",
+        "description": "The message posted as the id parameter will also be\nreturned.",
         "operationId": "Echo",
         "responses": {
           "default": {
@@ -39,13 +46,16 @@
         ],
         "tags": [
           "EchoService"
-        ]
+        ],
+        "externalDocs": {
+          "description": "Find out more about EchoService",
+          "url": "http://github.com/gengo/grpc-gateway"
+        }
       }
     },
     "/v1/example/echo_body": {
       "post": {
-        "summary": "EchoService.EchoBody",
-        "description": "EchoBody method receives a simple message and returns it.",
+        "summary": "EchoBody method receives a simple message and returns it.",
         "operationId": "EchoBody",
         "responses": {
           "default": {

--- a/examples/examplepb/echo_service.swagger.json
+++ b/examples/examplepb/echo_service.swagger.json
@@ -3,14 +3,8 @@
   "info": {
     "title": "Echo Service",
     "description": "Echo Service API consists of a single service which returns\na message.",
-    "version": "1.0",
-    "contact": {
-      "name": "gRPC-Gateway project",
-      "url": "https://github.com/gengo/grpc-gateway",
-      "email": "none@example.com"
-    }
+    "version": "version not set"
   },
-  "host": "localhost",
   "schemes": [
     "http",
     "https"
@@ -46,11 +40,7 @@
         ],
         "tags": [
           "EchoService"
-        ],
-        "externalDocs": {
-          "description": "Find out more about EchoService",
-          "url": "http://github.com/gengo/grpc-gateway"
-        }
+        ]
       }
     },
     "/v1/example/echo_body": {

--- a/examples/examplepb/echo_service.swagger.json
+++ b/examples/examplepb/echo_service.swagger.json
@@ -76,7 +76,8 @@
       "properties": {
         "id": {
           "type": "string",
-          "format": "string"
+          "format": "string",
+          "description": "Id represents the message identifier."
         }
       }
     }

--- a/examples/examplepb/flow_combination.pb.go
+++ b/examples/examplepb/flow_combination.pb.go
@@ -95,7 +95,7 @@ var _ grpc.ClientConn
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion1
+const _ = grpc.SupportPackageIsVersion2
 
 // Client API for FlowCombination service
 
@@ -368,16 +368,22 @@ func RegisterFlowCombinationServer(s *grpc.Server, srv FlowCombinationServer) {
 	s.RegisterService(&_FlowCombination_serviceDesc, srv)
 }
 
-func _FlowCombination_RpcEmptyRpc_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error) (interface{}, error) {
+func _FlowCombination_RpcEmptyRpc_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(EmptyProto)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
-	out, err := srv.(FlowCombinationServer).RpcEmptyRpc(ctx, in)
-	if err != nil {
-		return nil, err
+	if interceptor == nil {
+		return srv.(FlowCombinationServer).RpcEmptyRpc(ctx, in)
 	}
-	return out, nil
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/gengo.grpc.gateway.examples.examplepb.FlowCombination/RpcEmptyRpc",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(FlowCombinationServer).RpcEmptyRpc(ctx, req.(*EmptyProto))
+	}
+	return interceptor(ctx, in, info, handler)
 }
 
 func _FlowCombination_RpcEmptyStream_Handler(srv interface{}, stream grpc.ServerStream) error {
@@ -453,40 +459,58 @@ func (x *flowCombinationStreamEmptyStreamServer) Recv() (*EmptyProto, error) {
 	return m, nil
 }
 
-func _FlowCombination_RpcBodyRpc_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error) (interface{}, error) {
+func _FlowCombination_RpcBodyRpc_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(NonEmptyProto)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
-	out, err := srv.(FlowCombinationServer).RpcBodyRpc(ctx, in)
-	if err != nil {
-		return nil, err
+	if interceptor == nil {
+		return srv.(FlowCombinationServer).RpcBodyRpc(ctx, in)
 	}
-	return out, nil
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/gengo.grpc.gateway.examples.examplepb.FlowCombination/RpcBodyRpc",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(FlowCombinationServer).RpcBodyRpc(ctx, req.(*NonEmptyProto))
+	}
+	return interceptor(ctx, in, info, handler)
 }
 
-func _FlowCombination_RpcPathSingleNestedRpc_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error) (interface{}, error) {
+func _FlowCombination_RpcPathSingleNestedRpc_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(SingleNestedProto)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
-	out, err := srv.(FlowCombinationServer).RpcPathSingleNestedRpc(ctx, in)
-	if err != nil {
-		return nil, err
+	if interceptor == nil {
+		return srv.(FlowCombinationServer).RpcPathSingleNestedRpc(ctx, in)
 	}
-	return out, nil
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/gengo.grpc.gateway.examples.examplepb.FlowCombination/RpcPathSingleNestedRpc",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(FlowCombinationServer).RpcPathSingleNestedRpc(ctx, req.(*SingleNestedProto))
+	}
+	return interceptor(ctx, in, info, handler)
 }
 
-func _FlowCombination_RpcPathNestedRpc_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error) (interface{}, error) {
+func _FlowCombination_RpcPathNestedRpc_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(NestedProto)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
-	out, err := srv.(FlowCombinationServer).RpcPathNestedRpc(ctx, in)
-	if err != nil {
-		return nil, err
+	if interceptor == nil {
+		return srv.(FlowCombinationServer).RpcPathNestedRpc(ctx, in)
 	}
-	return out, nil
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/gengo.grpc.gateway.examples.examplepb.FlowCombination/RpcPathNestedRpc",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(FlowCombinationServer).RpcPathNestedRpc(ctx, req.(*NestedProto))
+	}
+	return interceptor(ctx, in, info, handler)
 }
 
 func _FlowCombination_RpcBodyStream_Handler(srv interface{}, stream grpc.ServerStream) error {

--- a/examples/examplepb/streamless_everything.proto
+++ b/examples/examplepb/streamless_everything.proto
@@ -6,11 +6,16 @@ import "google/api/annotations.proto";
 import "examples/sub/message.proto";
 
 message ABitOfEverything {
+	// Nested is nested type.
 	message Nested {
+		// name is nested field.
 		string name = 1;
 		uint32 amount = 2;
+		// DeepEnum is one or zero.
 		enum DeepEnum {
+			// FALSE is false.
 			FALSE = 0;
+			// TRUE is true.
 			TRUE = 1;
 		}
 		DeepEnum ok = 3;
@@ -44,8 +49,11 @@ message IdMessage {
 	string uuid = 1;
 }
 
+// NumericEnum is one or zero.
 enum NumericEnum {
+	// ZERO means 0
 	ZERO = 0;
+	// ONE means 1
 	ONE  = 1;
 }
 

--- a/examples/examplepb/streamless_everything.swagger.json
+++ b/examples/examplepb/streamless_everything.swagger.json
@@ -1,8 +1,8 @@
 {
   "swagger": "2.0",
   "info": {
-    "version": "",
-    "title": ""
+    "title": "examples/examplepb/streamless_everything.proto",
+    "version": "version not set"
   },
   "schemes": [
     "http",
@@ -17,7 +17,6 @@
   "paths": {
     "/v1/example/a_bit_of_everything": {
       "get": {
-        "summary": "ABitOfEverythingService.List",
         "operationId": "List",
         "responses": {
           "default": {
@@ -32,7 +31,6 @@
         ]
       },
       "post": {
-        "summary": "ABitOfEverythingService.CreateBody",
         "operationId": "CreateBody",
         "responses": {
           "default": {
@@ -59,7 +57,6 @@
     },
     "/v1/example/a_bit_of_everything/bulk": {
       "post": {
-        "summary": "ABitOfEverythingService.BulkCreate",
         "operationId": "BulkCreate",
         "responses": {
           "default": {
@@ -86,7 +83,6 @@
     },
     "/v1/example/a_bit_of_everything/echo": {
       "post": {
-        "summary": "ABitOfEverythingService.BulkEcho",
         "operationId": "BulkEcho",
         "responses": {
           "default": {
@@ -113,7 +109,6 @@
     },
     "/v1/example/a_bit_of_everything/echo/{value}": {
       "get": {
-        "summary": "ABitOfEverythingService.Echo",
         "operationId": "Echo",
         "responses": {
           "default": {
@@ -139,7 +134,6 @@
     },
     "/v1/example/a_bit_of_everything/{float_value}/{double_value}/{int64_value}/separator/{uint64_value}/{int32_value}/{fixed64_value}/{fixed32_value}/{bool_value}/{string_value}/{uint32_value}/{sfixed32_value}/{sfixed64_value}/{sint32_value}/{sint64_value}": {
       "post": {
-        "summary": "ABitOfEverythingService.Create",
         "operationId": "Create",
         "responses": {
           "default": {
@@ -256,7 +250,6 @@
     },
     "/v1/example/a_bit_of_everything/{uuid}": {
       "get": {
-        "summary": "ABitOfEverythingService.Lookup",
         "operationId": "Lookup",
         "responses": {
           "default": {
@@ -280,7 +273,6 @@
         ]
       },
       "delete": {
-        "summary": "ABitOfEverythingService.Delete",
         "operationId": "Delete",
         "responses": {
           "default": {
@@ -304,7 +296,6 @@
         ]
       },
       "put": {
-        "summary": "ABitOfEverythingService.Update",
         "operationId": "Update",
         "responses": {
           "default": {
@@ -363,7 +354,7 @@
         "TRUE"
       ],
       "default": "FALSE",
-      "description": "DeepEnum is one or zero. FALSE: FALSE is false. TRUE: TRUE is true."
+      "description": "DeepEnum is one or zero.\n\n - FALSE: FALSE is false.\n - TRUE: TRUE is true."
     },
     "examplepbABitOfEverything": {
       "type": "object",
@@ -466,7 +457,7 @@
         "ONE"
       ],
       "default": "ZERO",
-      "description": "NumericEnum is one or zero. ZERO: ZERO means 0 ONE: ONE means 1"
+      "description": "NumericEnum is one or zero.\n\n - ZERO: ZERO means 0\n - ONE: ONE means 1"
     },
     "subStringMessage": {
       "type": "object",

--- a/examples/examplepb/streamless_everything.swagger.json
+++ b/examples/examplepb/streamless_everything.swagger.json
@@ -429,7 +429,8 @@
         },
         "uint32_value": {
           "type": "integer",
-          "format": "int64"
+          "format": "int64",
+          "description": "TODO(yugui) add bytes_value"
         },
         "uint64_value": {
           "type": "integer",

--- a/examples/examplepb/streamless_everything.swagger.json
+++ b/examples/examplepb/streamless_everything.swagger.json
@@ -426,7 +426,7 @@
         "uint32_value": {
           "type": "integer",
           "format": "int64",
-          "description": "TODO(yugui) add bytes_value"
+          "title": "TODO(yugui) add bytes_value"
         },
         "uint64_value": {
           "type": "integer",

--- a/examples/examplepb/streamless_everything.swagger.json
+++ b/examples/examplepb/streamless_everything.swagger.json
@@ -339,6 +339,7 @@
   },
   "definitions": {
     "ABitOfEverythingNested": {
+      "type": "object",
       "properties": {
         "amount": {
           "type": "integer",
@@ -365,6 +366,7 @@
       "description": "DeepEnum is one or zero. FALSE: FALSE is false. TRUE: TRUE is true."
     },
     "examplepbABitOfEverything": {
+      "type": "object",
       "properties": {
         "bool_value": {
           "type": "boolean",
@@ -445,8 +447,11 @@
         }
       }
     },
-    "examplepbEmptyMessage": {},
+    "examplepbEmptyMessage": {
+      "type": "object"
+    },
     "examplepbIdMessage": {
+      "type": "object",
       "properties": {
         "uuid": {
           "type": "string",
@@ -464,6 +469,7 @@
       "description": "NumericEnum is one or zero. ZERO: ZERO means 0 ONE: ONE means 1"
     },
     "subStringMessage": {
+      "type": "object",
       "properties": {
         "value": {
           "type": "string",

--- a/examples/examplepb/streamless_everything.swagger.json
+++ b/examples/examplepb/streamless_everything.swagger.json
@@ -19,7 +19,7 @@
       "get": {
         "operationId": "List",
         "responses": {
-          "default": {
+          "200": {
             "description": "Description",
             "schema": {
               "$ref": "#/definitions/examplepbABitOfEverything"
@@ -33,7 +33,7 @@
       "post": {
         "operationId": "CreateBody",
         "responses": {
-          "default": {
+          "200": {
             "description": "Description",
             "schema": {
               "$ref": "#/definitions/examplepbABitOfEverything"
@@ -59,7 +59,7 @@
       "post": {
         "operationId": "BulkCreate",
         "responses": {
-          "default": {
+          "200": {
             "description": "Description",
             "schema": {
               "$ref": "#/definitions/examplepbEmptyMessage"
@@ -85,7 +85,7 @@
       "post": {
         "operationId": "BulkEcho",
         "responses": {
-          "default": {
+          "200": {
             "description": "Description",
             "schema": {
               "$ref": "#/definitions/subStringMessage"
@@ -111,7 +111,7 @@
       "get": {
         "operationId": "Echo",
         "responses": {
-          "default": {
+          "200": {
             "description": "Description",
             "schema": {
               "$ref": "#/definitions/subStringMessage"
@@ -136,7 +136,7 @@
       "post": {
         "operationId": "Create",
         "responses": {
-          "default": {
+          "200": {
             "description": "Description",
             "schema": {
               "$ref": "#/definitions/examplepbABitOfEverything"
@@ -252,7 +252,7 @@
       "get": {
         "operationId": "Lookup",
         "responses": {
-          "default": {
+          "200": {
             "description": "Description",
             "schema": {
               "$ref": "#/definitions/examplepbABitOfEverything"
@@ -275,7 +275,7 @@
       "delete": {
         "operationId": "Delete",
         "responses": {
-          "default": {
+          "200": {
             "description": "Description",
             "schema": {
               "$ref": "#/definitions/examplepbEmptyMessage"
@@ -298,7 +298,7 @@
       "put": {
         "operationId": "Update",
         "responses": {
-          "default": {
+          "200": {
             "description": "Description",
             "schema": {
               "$ref": "#/definitions/examplepbEmptyMessage"

--- a/examples/examplepb/streamless_everything.swagger.json
+++ b/examples/examplepb/streamless_everything.swagger.json
@@ -346,12 +346,14 @@
         },
         "name": {
           "type": "string",
-          "format": "string"
+          "format": "string",
+          "description": "name is nested field."
         },
         "ok": {
           "$ref": "#/definitions/NestedDeepEnum"
         }
-      }
+      },
+      "description": "Nested is nested type."
     },
     "NestedDeepEnum": {
       "type": "string",
@@ -359,7 +361,8 @@
         "FALSE",
         "TRUE"
       ],
-      "default": "FALSE"
+      "default": "FALSE",
+      "description": "DeepEnum is one or zero. FALSE: FALSE is false. TRUE: TRUE is true."
     },
     "examplepbABitOfEverything": {
       "properties": {
@@ -457,7 +460,8 @@
         "ZERO",
         "ONE"
       ],
-      "default": "ZERO"
+      "default": "ZERO",
+      "description": "NumericEnum is one or zero. ZERO: ZERO means 0 ONE: ONE means 1"
     },
     "subStringMessage": {
       "properties": {

--- a/protoc-gen-grpc-gateway/descriptor/registry.go
+++ b/protoc-gen-grpc-gateway/descriptor/registry.go
@@ -125,11 +125,12 @@ func (r *Registry) registerMsg(file *File, outerPath []string, msgs []*descripto
 }
 
 func (r *Registry) registerEnum(file *File, outerPath []string, enums []*descriptor.EnumDescriptorProto) {
-	for _, ed := range enums {
+	for i, ed := range enums {
 		e := &Enum{
 			File:                file,
 			Outers:              outerPath,
 			EnumDescriptorProto: ed,
+			Index:               i,
 		}
 		file.Enums = append(file.Enums, e)
 		r.enums[e.FQEN()] = e

--- a/protoc-gen-grpc-gateway/descriptor/registry.go
+++ b/protoc-gen-grpc-gateway/descriptor/registry.go
@@ -99,11 +99,12 @@ func (r *Registry) loadFile(file *descriptor.FileDescriptorProto) {
 }
 
 func (r *Registry) registerMsg(file *File, outerPath []string, msgs []*descriptor.DescriptorProto) {
-	for _, md := range msgs {
+	for i, md := range msgs {
 		m := &Message{
 			File:            file,
 			Outers:          outerPath,
 			DescriptorProto: md,
+			Index:           i,
 		}
 		for _, fd := range md.GetField() {
 			m.Fields = append(m.Fields, &Field{

--- a/protoc-gen-grpc-gateway/descriptor/types.go
+++ b/protoc-gen-grpc-gateway/descriptor/types.go
@@ -58,6 +58,9 @@ type Message struct {
 	Outers []string
 	*descriptor.DescriptorProto
 	Fields []*Field
+
+	// Index is proto path index of this message in File.
+	Index int
 }
 
 // FQMN returns a fully qualified message name of this message.

--- a/protoc-gen-grpc-gateway/descriptor/types.go
+++ b/protoc-gen-grpc-gateway/descriptor/types.go
@@ -100,6 +100,8 @@ type Enum struct {
 	// Outers is a list of outer messages if this enum is a nested type.
 	Outers []string
 	*descriptor.EnumDescriptorProto
+
+	Index int
 }
 
 // FQEN returns a fully qualified enum name of this enum.

--- a/protoc-gen-swagger/genswagger/template.go
+++ b/protoc-gen-swagger/genswagger/template.go
@@ -514,6 +514,16 @@ func applyTemplate(p param) (string, error) {
 }
 
 func protoComments(reg *descriptor.Registry, file *descriptor.File, outers []string, typeName string, typeIndex int32, fieldPaths ...int32) string {
+	if file.SourceCodeInfo == nil {
+		// Curious! A file without any source code info.
+		// This could be a test that's providing incomplete
+		// descriptor.File information.
+		//
+		// We could simply return no comments, but panic
+		// could make debugging easier.
+		panic("descriptor.File should not contain nil SourceCodeInfo")
+	}
+
 	outerPaths := make([]int32, len(outers))
 	for i := range outers {
 		location := ""

--- a/protoc-gen-swagger/genswagger/template.go
+++ b/protoc-gen-swagger/genswagger/template.go
@@ -456,7 +456,7 @@ func renderServices(services []*descriptor.Service, paths swaggerPathsObject, re
 					OperationId: fmt.Sprintf("%s", meth.GetName()),
 					Parameters:  parameters,
 					Responses: swaggerResponsesObject{
-						"default": swaggerResponseObject{
+						"200": swaggerResponseObject{
 							Description: "Description",
 							Schema: swaggerSchemaObject{
 								Ref: fmt.Sprintf("#/definitions/%s", fullyQualifiedNameToSwaggerName(meth.ResponseType.FQMN(), reg)),

--- a/protoc-gen-swagger/genswagger/template_test.go
+++ b/protoc-gen-swagger/genswagger/template_test.go
@@ -48,11 +48,12 @@ func TestApplyTemplateSimple(t *testing.T) {
 	}
 	file := descriptor.File{
 		FileDescriptorProto: &protodescriptor.FileDescriptorProto{
-			Name:        proto.String("example.proto"),
-			Package:     proto.String("example"),
-			Dependency:  []string{"a.example/b/c.proto", "a.example/d/e.proto"},
-			MessageType: []*protodescriptor.DescriptorProto{msgdesc},
-			Service:     []*protodescriptor.ServiceDescriptorProto{svc},
+			SourceCodeInfo: &protodescriptor.SourceCodeInfo{},
+			Name:           proto.String("example.proto"),
+			Package:        proto.String("example"),
+			Dependency:     []string{"a.example/b/c.proto", "a.example/d/e.proto"},
+			MessageType:    []*protodescriptor.DescriptorProto{msgdesc},
+			Service:        []*protodescriptor.ServiceDescriptorProto{svc},
 		},
 		GoPkg: descriptor.GoPackage{
 			Path: "example.com/path/to/example/example.pb",
@@ -182,10 +183,11 @@ func TestApplyTemplateRequestWithoutClientStreaming(t *testing.T) {
 	}
 	file := descriptor.File{
 		FileDescriptorProto: &protodescriptor.FileDescriptorProto{
-			Name:        proto.String("example.proto"),
-			Package:     proto.String("example"),
-			MessageType: []*protodescriptor.DescriptorProto{msgdesc, nesteddesc},
-			Service:     []*protodescriptor.ServiceDescriptorProto{svc},
+			SourceCodeInfo: &protodescriptor.SourceCodeInfo{},
+			Name:           proto.String("example.proto"),
+			Package:        proto.String("example"),
+			MessageType:    []*protodescriptor.DescriptorProto{msgdesc, nesteddesc},
+			Service:        []*protodescriptor.ServiceDescriptorProto{svc},
 		},
 		GoPkg: descriptor.GoPackage{
 			Path: "example.com/path/to/example/example.pb",
@@ -343,10 +345,11 @@ func TestApplyTemplateRequestWithClientStreaming(t *testing.T) {
 	}
 	file := descriptor.File{
 		FileDescriptorProto: &protodescriptor.FileDescriptorProto{
-			Name:        proto.String("example.proto"),
-			Package:     proto.String("example"),
-			MessageType: []*protodescriptor.DescriptorProto{msgdesc, nesteddesc},
-			Service:     []*protodescriptor.ServiceDescriptorProto{svc},
+			SourceCodeInfo: &protodescriptor.SourceCodeInfo{},
+			Name:           proto.String("example.proto"),
+			Package:        proto.String("example"),
+			MessageType:    []*protodescriptor.DescriptorProto{msgdesc, nesteddesc},
+			Service:        []*protodescriptor.ServiceDescriptorProto{svc},
 		},
 		GoPkg: descriptor.GoPackage{
 			Path: "example.com/path/to/example/example.pb",

--- a/protoc-gen-swagger/genswagger/types.go
+++ b/protoc-gen-swagger/genswagger/types.go
@@ -46,6 +46,7 @@ type swaggerPathItemObject struct {
 // http://swagger.io/specification/#operationObject
 type swaggerOperationObject struct {
 	Summary     string                  `json:"summary"`
+	Description string                  `json:"description,omitempty"`
 	OperationId string                  `json:"operationId"`
 	Responses   swaggerResponsesObject  `json:"responses"`
 	Parameters  swaggerParametersObject `json:"parameters,omitempty"`

--- a/protoc-gen-swagger/genswagger/types.go
+++ b/protoc-gen-swagger/genswagger/types.go
@@ -15,8 +15,33 @@ type binding struct {
 
 // http://swagger.io/specification/#infoObject
 type swaggerInfoObject struct {
-	Version string `json:"version"`
-	Title   string `json:"title"`
+	Title          string `json:"title"`
+	Description    string `json:"description,omitempty"`
+	TermsOfService string `json:"termsOfService,omitempty"`
+	Version        string `json:"version"`
+
+	Contact      *swaggerContactObject               `json:"contact,omitempty"`
+	License      *swaggerLicenseObject               `json:"license,omitempty"`
+	ExternalDocs *swaggerExternalDocumentationObject `json:"externalDocs,omitempty"`
+}
+
+// http://swagger.io/specification/#contactObject
+type swaggerContactObject struct {
+	Name  string `json:"name,omitempty"`
+	URL   string `json:"url,omitempty"`
+	Email string `json:"email,omitempty"`
+}
+
+// http://swagger.io/specification/#licenseObject
+type swaggerLicenseObject struct {
+	Name string `json:"name,omitempty"`
+	URL  string `json:"url,omitempty"`
+}
+
+// http://swagger.io/specification/#externalDocumentationObject
+type swaggerExternalDocumentationObject struct {
+	Description string `json:"description,omitempty"`
+	URL         string `json:"url,omitempty"`
 }
 
 // http://swagger.io/specification/#swaggerObject
@@ -45,12 +70,14 @@ type swaggerPathItemObject struct {
 
 // http://swagger.io/specification/#operationObject
 type swaggerOperationObject struct {
-	Summary     string                  `json:"summary"`
+	Summary     string                  `json:"summary,omitempty"`
 	Description string                  `json:"description,omitempty"`
 	OperationId string                  `json:"operationId"`
 	Responses   swaggerResponsesObject  `json:"responses"`
 	Parameters  swaggerParametersObject `json:"parameters,omitempty"`
 	Tags        []string                `json:"tags,omitempty"`
+
+	ExternalDocs *swaggerExternalDocumentationObject `json:"externalDocs,omitempty"`
 }
 
 type swaggerParametersObject []swaggerParameterObject

--- a/protoc-gen-swagger/genswagger/types.go
+++ b/protoc-gen-swagger/genswagger/types.go
@@ -129,6 +129,7 @@ type swaggerSchemaObject struct {
 	Default string   `json:"default,omitempty"`
 
 	Description string `json:"description,omitempty"`
+	Title       string `json:"title,omitempty"`
 }
 
 // http://swagger.io/specification/#referenceObject

--- a/protoc-gen-swagger/genswagger/types.go
+++ b/protoc-gen-swagger/genswagger/types.go
@@ -100,6 +100,8 @@ type swaggerSchemaObject struct {
 	// start from 0 index it will be great. I don't think that is a good assumption.
 	Enum    []string `json:"enum,omitempty"`
 	Default string   `json:"default,omitempty"`
+
+	Description string `json:"description,omitempty"`
 }
 
 // http://swagger.io/specification/#referenceObject


### PR DESCRIPTION
This PR adds support for extracting Swagger `description`s from protobuf comments.

This fixes #128.

---

**ORIGINAL OUTDATED TEXT FOLLOWS** 

While this is a first step in resolving gengo/grpc-gateway#128, this
needs to be cleaned up, and the same approach needs to be used for
messages, message fields, et al.

`echo_service.proto` has been annotated with extra comments in order to
demo the new descriptions.

Only the Swagger example has been regenerated, as my local generator
does not output all the expected fields in proto struct tags.

---

Aside from some uncleanliness and overzealous `panic()`ing, I'm also (obviously) unhappy with line 444. Other generators seem to be producing and comparing paths by joining them into comma-separated strings. They're also putting all the `SourceCodeInfo_Location`s into a `map` indexed by paths. 

(However, one thing that line 444 is doing good is dynamically looking up path IDs for 'message' type, etc. Even though it's using reflection for it, other generators written in Go seem to like to copy these constants into their own source code, which feels even worse.)

(For interested readers: More info on how to assemble a `SourceCodeInfo_Location` is [in google/protobuf's descriptor.proto](https://github.com/google/protobuf/blob/3b3c8ab/src/google/protobuf/descriptor.proto#L700).)


---

Similar to #133, I was unable to regenerate protobufs usefully. I fully expect Travis build to fail at this point.