### PR TITLE
Implement gRPC timeout support for inbound HTTP headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ More examples are available under `examples` directory.
 * Mapping streaming APIs to JSON streams
 * Mapping HTTP headers with `Grpc-Metadata-` prefix to gRPC metadata
 * Optionally emitting API definition for [Swagger](http://swagger.io).
+* Setting [gRPC timeouts](http://www.grpc.io/docs/guides/wire.html) through inbound HTTP `Grpc-Timeout` header.
 
 ### Want to support
 But not yet.

--- a/runtime/context_test.go
+++ b/runtime/context_test.go
@@ -10,27 +10,45 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-func TestAnnotateContext(t *testing.T) {
+const (
+	emptyForwardMetaCount = 2
+)
+
+func TestAnnotateContext_WorksWithEmpty(t *testing.T) {
 	ctx := context.Background()
 
-	request, err := http.NewRequest("GET", "http://localhost", nil)
+	request, err := http.NewRequest("GET", "http://www.example.com", nil)
 	if err != nil {
-		t.Fatalf("http.NewRequest(%q, %q, nil) failed with %v; want success", "GET", "http://localhost", err)
+		t.Fatalf("http.NewRequest(%q, %q, nil) failed with %v; want success", "GET", "http://www.example.com", err)
 	}
+	// Make sure we set a remote.
+	request.RemoteAddr = "192.168.0.1:12345"
+
 	request.Header.Add("Some-Irrelevant-Header", "some value")
 	annotated := runtime.AnnotateContext(ctx, request)
-	if annotated != ctx {
-		t.Errorf("AnnotateContext(ctx, request) = %v; want %v", annotated, ctx)
+	md, ok := metadata.FromContext(annotated)
+	if !ok || len(md) != emptyForwardMetaCount {
+		t.Errorf("Expected 2 metadata items in context; got %v", md)
 	}
+}
 
+func TestAnnotateContext_ForwardsGrpcMetadata(t *testing.T) {
+	ctx := context.Background()
+	request, err := http.NewRequest("GET", "http://www.example.com", nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest(%q, %q, nil) failed with %v; want success", "GET", "http://www.example.com", err)
+	}
+	request.RemoteAddr = "192.168.0.1:12345"
+
+	request.Header.Add("Some-Irrelevant-Header", "some value")
 	request.Header.Add("Grpc-Metadata-FooBar", "Value1")
 	request.Header.Add("Grpc-Metadata-Foo-BAZ", "Value2")
 	request.Header.Add("Grpc-Metadata-foo-bAz", "Value3")
 	request.Header.Add("Authorization", "Token 1234567890")
-	annotated = runtime.AnnotateContext(ctx, request)
+	annotated := runtime.AnnotateContext(ctx, request)
 	md, ok := metadata.FromContext(annotated)
-	if !ok || len(md) != 3 {
-		t.Errorf("Expected 3 metadata items in context; got %v", md)
+	if !ok || len(md) != emptyForwardMetaCount+3 {
+		t.Errorf("Expected 5 metadata items in context; got %v", md)
 	}
 	if got, want := md["foobar"], []string{"Value1"}; !reflect.DeepEqual(got, want) {
 		t.Errorf(`md["foobar"] = %q; want %q`, got, want)
@@ -40,5 +58,28 @@ func TestAnnotateContext(t *testing.T) {
 	}
 	if got, want := md["authorization"], []string{"Token 1234567890"}; !reflect.DeepEqual(got, want) {
 		t.Errorf(`md["authorization"] = %q want %q`, got, want)
+	}
+}
+
+func TestAnnotateContext_XForwardedFor(t *testing.T) {
+	ctx := context.Background()
+	request, err := http.NewRequest("GET", "http://bar.foo.example.com", nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest(%q, %q, nil) failed with %v; want success", "GET", "http://bar.foo.example.com", err)
+	}
+	request.Header.Add("X-Forwarded-For", "192.168.0.100") // client
+	request.RemoteAddr = "8.8.8.8:12345"                   // proxy
+
+	annotated := runtime.AnnotateContext(ctx, request)
+	md, ok := metadata.FromContext(annotated)
+	if !ok || len(md) != emptyForwardMetaCount {
+		t.Errorf("Expected 2 metadata items in context; got %v", md)
+	}
+	if got, want := md["x-forwarded-host"], []string{"bar.foo.example.com"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("md[\"host\"] = %v; want %v", got, want)
+	}
+	// Note: it must be in order client, proxy1, proxy2
+	if got, want := md["x-forwarded-for"], []string{"192.168.0.100, 8.8.8.8"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("md[\"x-forwarded-for\"] = %v want %v", got, want)
 	}
 }


### PR DESCRIPTION
This PR implements support for Grpc-Timeout support https://github.com/gengo/grpc-gateway/issues/107
It is based ontop of changes in https://github.com/gengo/grpc-gateway/pull/65 so that they can be merged one after the other.