### PR TITLE
Include HTTP req.remoteAddr in gRPC ctx

### DIFF
--- a/runtime/context.go
+++ b/runtime/context.go
@@ -26,7 +26,7 @@ func AnnotateContext(ctx context.Context, req *http.Request) context.Context {
 
 	for key, vals := range req.Header {
 		for _, val := range vals {
-			if key == "Authorization" {
+			if strings.ToLower(key) == "authorization" {
 				pairs = append(pairs, key, val)
 				continue
 			}

--- a/runtime/context.go
+++ b/runtime/context.go
@@ -14,14 +14,19 @@ const metadataTrailerPrefix = "Grpc-Trailer-"
 /*
 AnnotateContext adds context information such as metadata from the request.
 
-If there are no metadata headers in the request, then the context returned
-will be the same context.
+At a minimum, the RemoteAddr is included in the fashion of "X-Forwarded-For",
+except that the forwarded destination is not another HTTP service but rather
+a gRPC service.
 */
 func AnnotateContext(ctx context.Context, req *http.Request) context.Context {
 	var pairs []string
+
+	// Include the original RemoteAddr, something the gRPC service may need in the ctx
+	pairs = append(pairs, "RemoteAddr", req.RemoteAddr)
+
 	for key, vals := range req.Header {
 		for _, val := range vals {
-			if strings.ToLower(key) == "authorization" {
+			if key == "Authorization" {
 				pairs = append(pairs, key, val)
 				continue
 			}

--- a/runtime/context_test.go
+++ b/runtime/context_test.go
@@ -22,7 +22,7 @@ func TestAnnotateContext(t *testing.T) {
 	request.Header.Add("Some-Irrelevant-Header", "some value")
 	annotated := runtime.AnnotateContext(ctx, request)
 	ctx = metadata.NewContext(ctx, metadata.Pairs("RemoteAddr", "127.0.0.1"))
-	if annotated != ctx {
+	if !reflect.DeepEqual(annotated, ctx) {
 		t.Errorf("AnnotateContext(ctx, request) = %v; want %v", annotated, ctx)
 	}
 

--- a/runtime/context_test.go
+++ b/runtime/context_test.go
@@ -17,8 +17,11 @@ func TestAnnotateContext(t *testing.T) {
 	if err != nil {
 		t.Fatalf("http.NewRequest(%q, %q, nil) failed with %v; want success", "GET", "http://localhost", err)
 	}
+
+	request.RemoteAddr = "127.0.0.1"
 	request.Header.Add("Some-Irrelevant-Header", "some value")
 	annotated := runtime.AnnotateContext(ctx, request)
+	ctx = metadata.NewContext(ctx, metadata.Pairs("RemoteAddr", "127.0.0.1"))
 	if annotated != ctx {
 		t.Errorf("AnnotateContext(ctx, request) = %v; want %v", annotated, ctx)
 	}
@@ -29,8 +32,8 @@ func TestAnnotateContext(t *testing.T) {
 	request.Header.Add("Authorization", "Token 1234567890")
 	annotated = runtime.AnnotateContext(ctx, request)
 	md, ok := metadata.FromContext(annotated)
-	if !ok || len(md) != 3 {
-		t.Errorf("Expected 3 metadata items in context; got %v", md)
+	if !ok || len(md) != 4 {
+		t.Errorf("Expected 4 metadata items in context; got %v", md)
 	}
 	if got, want := md["foobar"], []string{"Value1"}; !reflect.DeepEqual(got, want) {
 		t.Errorf(`md["foobar"] = %q; want %q`, got, want)


### PR DESCRIPTION
This annotates the gRPC request context with the HTTP remote address, which is a solution the problem of the gRPC service not being able to correctly identify the remote peer address due to the proxy-forwarding nature of grpc-gateway, which I described in https://github.com/gengo/grpc-gateway/issues/173.