### PR TITLE
Fix asynchronous send in gateway codegen

### DIFF
--- a/examples/examplepb/a_bit_of_everything.pb.go
+++ b/examples/examplepb/a_bit_of_everything.pb.go
@@ -8,7 +8,7 @@ import proto "github.com/golang/protobuf/proto"
 import fmt "fmt"
 import math "math"
 import _ "github.com/gengo/grpc-gateway/third_party/googleapis/google/api"
-import google_protobuf1 "github.com/golang/protobuf/ptypes/empty"
+import google_protobuf1 "google/protobuf"
 import gengo_grpc_gateway_examples_sub "github.com/gengo/grpc-gateway/examples/sub"
 import sub2 "github.com/gengo/grpc-gateway/examples/sub2"
 

--- a/examples/examplepb/a_bit_of_everything.pb.gw.go
+++ b/examples/examplepb/a_bit_of_everything.pb.gw.go
@@ -10,6 +10,7 @@ It translates gRPC into RESTful JSON APIs.
 package examplepb
 
 import (
+	"google/protobuf"
 	"io"
 	"net/http"
 
@@ -18,7 +19,6 @@ import (
 	"github.com/gengo/grpc-gateway/runtime"
 	"github.com/gengo/grpc-gateway/utilities"
 	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/ptypes/empty"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -406,7 +406,7 @@ func request_ABitOfEverythingService_DeepPathEcho_0(ctx context.Context, marshal
 }
 
 func request_ABitOfEverythingService_Timeout_0(ctx context.Context, marshaler runtime.Marshaler, client ABitOfEverythingServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq empty.Empty
+	var protoReq google_protobuf.Empty
 	var metadata runtime.ServerMetadata
 
 	msg, err := client.Timeout(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))

--- a/examples/examplepb/flow_combination.pb.gw.go
+++ b/examples/examplepb/flow_combination.pb.gw.go
@@ -115,12 +115,6 @@ func request_FlowCombination_StreamEmptyStream_0(ctx context.Context, marshaler 
 		}
 		return nil
 	}
-	if err := handleSend(); err != nil {
-		if err := stream.CloseSend(); err != nil {
-			grpclog.Printf("Failed to terminate client stream: %v", err)
-		}
-		return nil, metadata, err
-	}
 	go func() {
 		for {
 			if err := handleSend(); err != nil {

--- a/examples/examplepb/stream.pb.go
+++ b/examples/examplepb/stream.pb.go
@@ -8,7 +8,7 @@ import proto "github.com/golang/protobuf/proto"
 import fmt "fmt"
 import math "math"
 import _ "github.com/gengo/grpc-gateway/third_party/googleapis/google/api"
-import google_protobuf1 "github.com/golang/protobuf/ptypes/empty"
+import google_protobuf1 "google/protobuf"
 import gengo_grpc_gateway_examples_sub "github.com/gengo/grpc-gateway/examples/sub"
 
 import (

--- a/examples/examplepb/stream.pb.gw.go
+++ b/examples/examplepb/stream.pb.gw.go
@@ -10,6 +10,7 @@ It translates gRPC into RESTful JSON APIs.
 package examplepb
 
 import (
+	"google/protobuf"
 	"io"
 	"net/http"
 
@@ -17,7 +18,6 @@ import (
 	"github.com/gengo/grpc-gateway/runtime"
 	"github.com/gengo/grpc-gateway/utilities"
 	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/ptypes/empty"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -71,7 +71,7 @@ func request_StreamService_BulkCreate_0(ctx context.Context, marshaler runtime.M
 }
 
 func request_StreamService_List_0(ctx context.Context, marshaler runtime.Marshaler, client StreamServiceClient, req *http.Request, pathParams map[string]string) (StreamService_ListClient, runtime.ServerMetadata, error) {
-	var protoReq empty.Empty
+	var protoReq google_protobuf.Empty
 	var metadata runtime.ServerMetadata
 
 	stream, err := client.List(ctx, &protoReq)
@@ -107,12 +107,6 @@ func request_StreamService_BulkEcho_0(ctx context.Context, marshaler runtime.Mar
 			return err
 		}
 		return nil
-	}
-	if err := handleSend(); err != nil {
-		if err := stream.CloseSend(); err != nil {
-			grpclog.Printf("Failed to terminate client stream: %v", err)
-		}
-		return nil, metadata, err
 	}
 	go func() {
 		for {

--- a/protoc-gen-grpc-gateway/gengateway/template.go
+++ b/protoc-gen-grpc-gateway/gengateway/template.go
@@ -258,12 +258,6 @@ var (
 		}
 		return nil
 	}
-	if err := handleSend(); err != nil {
-		if err := stream.CloseSend(); err != nil {
-			grpclog.Printf("Failed to terminate client stream: %v", err)
-		}
-		return nil, metadata, err
-	}
 	go func() {
 		for {
 			if err := handleSend(); err != nil {


### PR DESCRIPTION
I'd like to check if it was expected behavior since i hit an issue when stream will not become bidirectional until first send occurred.

It seems to me that the sync send was left in template - is that intended behavior?